### PR TITLE
Refactor native library loading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,13 @@ plugins {
     id 'com.palantir.git-version' version '0.5.2'
 }
 
+compileJava {
+    options.compilerArgs = ['-proc:none', '-Xlint:all','-Werror','-Xdiags:verbose']
+}
+compileTestJava {
+    options.compilerArgs = ['-proc:none', '-Xlint:all','-Werror','-Xdiags:verbose']
+}
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -21,6 +28,10 @@ dependencies {
     testCompile 'org.testng:testng:6.9.9'
 }
 
+task wrapper(type: Wrapper) {
+    gradleVersion = '3.2.1'
+}
+
 //===================================================================
 // build
 //===================================================================
@@ -32,7 +43,7 @@ task cmakeConfig(type: Exec) {
     doFirst {mkdir nativeBuildDir}
     workingDir nativeBuildDir
     commandLine 'cmake', '-Wno-dev', projectDir
-    inputs.files 'CMakeLists.txt'
+    inputs.files fileTree(projectDir) {include '**/CMakeLists.txt'}
     outputs.files "$nativeBuildDir/Makefile"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 07 10:08:11 EST 2016
+#Sat Dec 17 20:23:14 EST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,90 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+if "%@eval[2+2]" == "4" goto 4NT_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+goto execute
+
+:4NT_args
+@rem Get arguments from the 4NT Shell from JP Software
+set CMD_LINE_ARGS=%$
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/src/main/java/com/intel/gkl/NativeLibraryLoader.java
+++ b/src/main/java/com/intel/gkl/NativeLibraryLoader.java
@@ -1,0 +1,95 @@
+package com.intel.gkl;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ *
+ */
+public final class NativeLibraryLoader {
+    private static final Logger logger = LogManager.getLogger(NativeLibraryLoader.class);
+    private static final String USE_LIB_PATH = "USE_LIB_PATH";
+    private static final Set<String> loadedLibraries = new HashSet<String>();
+
+    private final String libraryName;
+
+    public NativeLibraryLoader(String libraryName) {
+        this.libraryName = libraryName;
+    }
+
+    public boolean isLoaded() {
+        return loadedLibraries.contains(libraryName);
+    }
+
+    /**
+     * Tries to load the GKL shared library. If AVX is not supported, it returns {@code false} without
+     * trying to load the library.
+     *
+     * If GKL is loaded from a jar file, the shared library file is extracted to the
+     * {@code tempDir} directory first.
+     *
+     * @param tempDir directory where the shared library file is extracted
+     * @param libFileName name of the library file to be loaded
+     * @return {@code true} if GKL loaded successfully, {@code false} otherwise
+     */
+    /**
+     *
+     * @param tempDir
+     * @return {@code true} if GKL loaded successfully, {@code false} otherwise
+     */
+    public synchronized boolean load(File tempDir) {
+        if (isLoaded()) {
+            return true;
+        }
+
+        // try to load from Java library path if USE_LIB_PATH env var is defined
+        if (System.getenv(USE_LIB_PATH) != null) {
+            try {
+                String javaLibraryPath = System.getProperty("java.library.path");
+                logger.info(String.format("Trying to load native library from: \n\t%s",
+                        javaLibraryPath.replaceAll(":", "\n\t")));
+                System.loadLibrary(libraryName);
+                logger.info("Native library loaded from Java library path.");
+
+                return true;
+            } catch (UnsatisfiedLinkError ule) {
+                logger.warn("Unable to load library.");
+                return false;
+            }
+        }
+
+        // try to extract from classpath
+        try {
+            String resourcePath = "native/" +  System.mapLibraryName(libraryName);
+            URL inputUrl = NativeLibraryLoader.class.getResource(resourcePath);
+            if (inputUrl == null) {
+                logger.warn("Unable to find native library: " + resourcePath);
+                return false;
+            }
+
+            logger.info(String.format("Trying to load native library from:\n\t%s", inputUrl.toString()));
+
+            File temp = File.createTempFile(FilenameUtils.getBaseName(resourcePath),
+                    "." + FilenameUtils.getExtension(resourcePath), tempDir);
+            FileUtils.copyURLToFile(inputUrl, temp);
+            temp.deleteOnExit();
+            logger.debug(String.format("Extracted native to %s\n", temp.getAbsolutePath()));
+
+            System.load(temp.getAbsolutePath());
+            logger.info("Native library loaded from classpath.");
+        } catch (Exception e) {
+            logger.warn("Unable to load native library.");
+            return false;
+        }
+
+        loadedLibraries.add(libraryName);
+        return true;
+    }
+}

--- a/src/main/java/com/intel/gkl/ftz/FTZ.java
+++ b/src/main/java/com/intel/gkl/ftz/FTZ.java
@@ -1,73 +1,31 @@
 package com.intel.gkl.ftz;
 
-import com.intel.gkl.IntelGKLUtils;
+import com.intel.gkl.NativeLibraryLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.broadinstitute.gatk.nativebindings.NativeLibrary;
 
 import java.io.File;
 
-public class FTZ implements NativeLibrary {
+public final class FTZ implements NativeLibrary {
+    private static final Logger logger = LogManager.getLogger(FTZ.class);
+    private static final NativeLibraryLoader libraryLoader = new NativeLibraryLoader("gkl_ftz");
 
-    private final static Logger logger = LogManager.getLogger(FTZ.class);
-
-    private boolean isGklLoaded;
-    private static final String libFileName = "gkl_ftz";
-
-
-    public FTZ() {
-        this(null);
+    @Override
+    public synchronized boolean load(File tempDir) {
+        return libraryLoader.load(tempDir);
     }
 
-    public boolean load() {
-        return load(null, libFileName);
-    }
-
-    public boolean load(File tempDir) {
-        return load(tempDir, libFileName);
-    }
-
-    public boolean load(File tmpDir, String libFileName) {
-        isGklLoaded = IntelGKLUtils.load(tmpDir, libFileName);
-
-        if(isGklLoaded){
-            logger.warn("GKL Loaded.");
-            return true;
-        }
-
-        else {
-            logger.warn("FTZ control is not supported on this platform.");
-            return false;
-        }
-
-    }
-
-
-    public FTZ(File tmpDir) {
-        isGklLoaded = IntelGKLUtils.load(tmpDir, libFileName);
-
-        if(isGklLoaded){
-            logger.warn("GKL Loaded.");
-        }
-
-        if (!isGklLoaded) {
-            logger.warn("FTZ control is not supported on this platform.");
-        }
-
-    }
-
-    public boolean isSupported() {
-        return isGklLoaded;
+    public boolean isLoaded() {
+        return libraryLoader.isLoaded();
     }
 
     public boolean getFlushToZero() {
-        return isGklLoaded && getFlushToZeroNative();
+        return getFlushToZeroNative();
     }
 
     public void setFlushToZero(boolean value) {
-        if (isGklLoaded) {
-            setFlushToZeroNative(value);
-        }
+        setFlushToZeroNative(value);
     }
 
     private native boolean getFlushToZeroNative();

--- a/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
+++ b/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
@@ -1,7 +1,7 @@
 package com.intel.gkl.pairhmm;
 
-
 import com.intel.gkl.IntelGKLUtils;
+import com.intel.gkl.NativeLibraryLoader;
 import org.broadinstitute.gatk.nativebindings.pairhmm.HaplotypeDataHolder;
 import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeArguments;
 import org.broadinstitute.gatk.nativebindings.pairhmm.PairHMMNativeBinding;
@@ -10,53 +10,22 @@ import org.broadinstitute.gatk.nativebindings.pairhmm.ReadDataHolder;
 import java.io.File;
 
 public class IntelPairHmm implements PairHMMNativeBinding {
+    private static NativeLibraryLoader libraryLoader;
 
-    public IntelPairHmm () {
-        setLibFileName("gkl_pairhmm");
-        setIsLoaded(false);
+    protected static void setLibraryName(String libraryName) {
+        libraryLoader = new NativeLibraryLoader(libraryName);
     }
 
-
-    public static String libFileName = "gkl_pairhmm";
-    public static boolean isLoaded = false;
-
-
-    /**
-     * Load native library using system temp directory to store the shared object.
-     *
-     * @return true if IntelPairHmm is supported on the platform
-     */
-    public boolean load() {
-        return load(null, libFileName);
+    public IntelPairHmm() {
+        setLibraryName("gkl_pairhmm");
     }
 
-    public boolean load(File tempDir) {
-        return load(tempDir, libFileName);
-    }
-    /**
-     * Load native library using tmpDir to store the shared object.
-     *
-     * @param tmpDir the directory used to store a copy of the shared object
-     * @param libFileName library name to be loaded
-     * @return true if IntelPairHmm is supported on the platform
-     */
-
-    public boolean load(File tmpDir, String libFileName) {
-        if(!isLoaded) {
-            isLoaded = IntelGKLUtils.load(tmpDir, libFileName);
-            return isLoaded;
+    @Override
+    public synchronized boolean load(File tempDir) {
+        if (!IntelGKLUtils.isAvxSupported()) {
+            return false;
         }
-        return true;
-    }
-
-    public static void setLibFileName(String newlibFileName)
-    {
-        libFileName = newlibFileName;
-    }
-
-    public static void setIsLoaded(boolean flag)
-    {
-        isLoaded = flag;
+        return libraryLoader.load(tempDir);
     }
 
     /**
@@ -64,8 +33,6 @@ public class IntelPairHmm implements PairHMMNativeBinding {
      *
      * @param args the args used to configure native PairHMM
      */
-
-
     public void initialize(PairHMMNativeArguments args) {
         if(args == null)
         {

--- a/src/main/java/com/intel/gkl/pairhmm/IntelPairHmmOMP.java
+++ b/src/main/java/com/intel/gkl/pairhmm/IntelPairHmmOMP.java
@@ -3,10 +3,9 @@ package com.intel.gkl.pairhmm;
 /**
  * Created by pnvaidya on 11/2/16.
  */
-public class IntelPairHmmOMP extends IntelPairHmm  {
+public final class IntelPairHmmOMP extends IntelPairHmm {
 
    public IntelPairHmmOMP() {
-        setLibFileName("gkl_pairhmm_omp");
-        setIsLoaded(false);
-    }
+       setLibraryName("gkl_pairhmm_omp");
+   }
 }

--- a/src/main/native/compression/IntelInflater.cc
+++ b/src/main/native/compression/IntelInflater.cc
@@ -50,7 +50,6 @@ extern "C" {
 static jfieldID FID_inf_lz_stream;
 static jfieldID FID_inf_inputBuffer;
 static jfieldID FID_inf_inputBufferLength;
-static jfieldID FID_inf_endOfStream;
 static jfieldID FID_inf_finished;
 
 
@@ -63,7 +62,6 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelInflater_initNative
   FID_inf_lz_stream = env->GetFieldID(cls, "lz_stream", "J");
   FID_inf_inputBuffer = env->GetFieldID(cls, "inputBuffer", "[B");
   FID_inf_inputBufferLength = env->GetFieldID(cls, "inputBufferLength", "I");
-  FID_inf_endOfStream = env->GetFieldID(cls, "endOfStream", "Z");
   FID_inf_finished = env->GetFieldID(cls, "finished", "Z");
 
 }
@@ -87,7 +85,6 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelInflater_resetNative
             lz_stream->avail_in = 0;
             lz_stream->next_in = Z_NULL;
 
-      fprintf(stdout,"%c",nowrap);
       int ret = inflateInit2(lz_stream, nowrap ? -MAX_WBITS : MAX_WBITS);
       if (ret != Z_OK) {
         jclass Exception = env->FindClass("java/lang/Exception");

--- a/src/test/java/com/intel/gkl/compression/DeflaterUnitTest.java
+++ b/src/test/java/com/intel/gkl/compression/DeflaterUnitTest.java
@@ -48,6 +48,12 @@ public class DeflaterUnitTest {
         }
     }
 
+    @Test(enabled = false)
+    public void loadLibrary() {
+        final boolean isSupported = new IntelDeflater().load(null);
+        Assert.assertTrue(isSupported);
+    }
+
     @Test(enabled = true)
     public void randomDNATest() {
         final int LEN = 60*1024*1024;
@@ -55,7 +61,7 @@ public class DeflaterUnitTest {
         final byte[] compressed = new byte[2*LEN];
         final byte[] result = new byte[LEN];
 
-        final boolean isSupported = new IntelInflater().load();
+        final boolean isSupported = new IntelInflater().load(null);
         Assert.assertTrue(isSupported);
 
         final IntelDeflaterFactory intelDeflaterFactory = new IntelDeflaterFactory();
@@ -97,5 +103,4 @@ public class DeflaterUnitTest {
             Assert.assertEquals(input, result);
         }
     }
-
 }

--- a/src/test/java/com/intel/gkl/ftz/FtzUnitTest.java
+++ b/src/test/java/com/intel/gkl/ftz/FtzUnitTest.java
@@ -9,9 +9,10 @@ public class FtzUnitTest {
 
     @Test(enabled = true)
     public void simpleTest() {
-        FTZ ftz = new FTZ();
-        assert(ftz.isSupported());
+        boolean ftzIsLoaded = new FTZ().load(null);
+        assert(ftzIsLoaded);
 
+        FTZ ftz = new FTZ();
 
         log.info("Test setting FTZ");
         boolean value = false;
@@ -31,7 +32,8 @@ public class FtzUnitTest {
 
         public void run() {
             FTZ ftz = new FTZ();
-            assert(ftz.isSupported());
+            ftz.load(null);
+            assert(ftz.isLoaded());
 
             ftzValue = ftz.getFlushToZero();
             log.info("Child thread FTZ = " + ftzValue);
@@ -41,7 +43,8 @@ public class FtzUnitTest {
     @Test(enabled = true)
     public void childThreadTest() {
         FTZ ftz = new FTZ();
-        assert (ftz.isSupported());
+        ftz.load(null);
+        assert (ftz.isLoaded());
 
         log.info("Parent setting FTZ = true");
 

--- a/src/test/java/com/intel/gkl/pairhmm/PairHmmUnitTest.java
+++ b/src/test/java/com/intel/gkl/pairhmm/PairHmmUnitTest.java
@@ -21,7 +21,7 @@ public class PairHmmUnitTest {
     @Test(enabled = true)
     public void simpleTest() {
 
-        final boolean isloaded = new IntelPairHmm().load();
+        final boolean isloaded = new IntelPairHmm().load(null);
 
         final IntelPairHmm pairHmm = new IntelPairHmm();
         Assert.assertTrue(isloaded);
@@ -56,11 +56,11 @@ public class PairHmmUnitTest {
 
     @Test(enabled = true)
     public void omp_Test() {
-        final boolean isSupported = new IntelPairHmmOMP().load();
+        final boolean isSupported = new IntelPairHmmOMP().load(null);
 
         if(!isSupported) {
             IntelPairHmm pairHmm = new IntelPairHmm();
-            final boolean isloaded = new IntelPairHmm().load();
+            final boolean isloaded = new IntelPairHmm().load(null);
 
 
             Assert.assertTrue(isloaded);
@@ -128,7 +128,7 @@ public class PairHmmUnitTest {
     @Test(enabled = true)
     public void dataFileTest() {
         // load native library
-        final boolean isSupported = new IntelPairHmm().load();
+        final boolean isSupported = new IntelPairHmm().load(null);
         Assert.assertTrue(isSupported);
 
         // instantiate and initialize IntelPairHmm
@@ -185,7 +185,7 @@ public class PairHmmUnitTest {
     @Test(enabled = false)
     public void testDataFileBatchTest() {
         // load native library
-        final boolean isSupported = new IntelPairHmm().load();
+        final boolean isSupported = new IntelPairHmm().load(null);
         Assert.assertTrue(isSupported);
 
         // instantiate and initialize IntelPairHmm


### PR DESCRIPTION
- Refactored how native libraries are loaded by adding a `NativeLibraryLoader` class. The `NativeLibraryLoader` class ensures that shared libraries in GKL are loaded once per JVM.
- Catch all exceptions during native library load (resolves #38)
- Restored AVX check (resolves #39)
