### PR TITLE
Fix issue with inflater/deflater garbage collection

### DIFF
--- a/src/main/java/com/intel/gkl/compression/IntelDeflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelDeflater.java
@@ -195,6 +195,9 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
      */
     @Override
     public void end() {
-        endNative();
+        if(lz_stream != 0) {
+            endNative();
+            lz_stream = 0;
+        }
     }
 }

--- a/src/main/java/com/intel/gkl/compression/IntelInflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflater.java
@@ -178,15 +178,9 @@ public final class IntelInflater extends Inflater implements NativeLibrary {
      */
     @Override
     public void end() {
-
-        if(lz_stream !=0)
-        {
+        if(lz_stream != 0) {
             endNative();
-            lz_stream=0;
+            lz_stream = 0;
         }
     }
-
-    @Override
-    protected void finalize() {}
-
 }


### PR DESCRIPTION
For https://github.com/broadinstitute/gatk/issues/2535
* Guard `endNative()` call in `IntelDeflater.end()` so it is only called once, which prevents multiple `free` calls
* Remove override of `IntelInflater.finalize()` to allow JVM to garbage collect properly
