### PR TITLE
Allocate memory for FPGA batch results; this fixes segfault when usin…

### DIFF
--- a/src/main/native/pairhmm/JavaData.h
+++ b/src/main/native/pairhmm/JavaData.h
@@ -102,6 +102,9 @@ class JavaData {
     }
     m_batch.haps = m_haps.data();
 
+    // allocate results
+    m_batch.results = (float*)malloc(sizeof(float) * num_testcases);
+
     m_batch.num_cells = m_total_cells;
     
     return m_batch;


### PR DESCRIPTION
…g FPGA-implementation of PairHMM in 'private' mode, as the pairhmm_shacc library is expecting the Batch results to be pre-allocated when it receives it.