### PR TITLE
Made it compile with clang

### DIFF
--- a/src/main/native/utils/utils.cc
+++ b/src/main/native/utils/utils.cc
@@ -49,7 +49,9 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_IntelGKLUtils_setFlushToZeroNative
 JNIEXPORT jboolean JNICALL Java_com_intel_gkl_IntelGKLUtils_isAvxSupportedNative
   (JNIEnv *env, jobject obj)
 {
+#if !defined(__clang__)
   __builtin_cpu_init();
+#endif
   return __builtin_cpu_supports("avx") ? true : false;
 }
 


### PR DESCRIPTION
`__builtin_cpu_init()` does not exist (and is not necessary) in clang