### PR TITLE
Eba avx detect fix mac2

### DIFF
--- a/src/main/native/utils/utils.cc
+++ b/src/main/native/utils/utils.cc
@@ -52,7 +52,8 @@ JNIEXPORT jboolean JNICALL Java_com_intel_gkl_IntelGKLUtils_isAvxSupportedNative
 #if !defined(__clang__)
   __builtin_cpu_init();
 #endif
-  return __builtin_cpu_supports("avx") ? true : false;
+  volatile int r = __builtin_cpu_supports("avx");
+  return r ? true : false;
 }
 
 /*

--- a/src/main/native/utils/utils.cc
+++ b/src/main/native/utils/utils.cc
@@ -2,6 +2,7 @@
   #include <intrin.h> // SIMD intrinsics for Windows
 #else
   #include <x86intrin.h> // SIMD intrinsics for GCC
+  #include <stdint.h>
 #endif
 
 #ifdef linux
@@ -40,20 +41,61 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_IntelGKLUtils_setFlushToZeroNative
   }
 }
 
+// helper function
+static 
+void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t* abcd)
+{
+#if defined(_MSC_VER)
+  __cpuidex(abcd, eax, ecx);
+#else
+  uint32_t ebx, edx;
+# if defined( __i386__ ) && defined ( __PIC__ )
+  /* in case of PIC under 32-bit EBX cannot be clobbered */
+  __asm__ ( "movl %%ebx, %%edi \n\t cpuid \n\t xchgl %%ebx, %%edi" : "=D" (ebx),
+# else
+  __asm__ ( "cpuid" : "+b" (ebx),
+# endif
+            "+a" (eax), "+c" (ecx), "=d" (edx) );
+  abcd[0] = eax; abcd[1] = ebx; abcd[2] = ecx; abcd[3] = edx;
+#endif
+}     
+
+// helper function
+static
+int check_xcr0_ymm() 
+{
+  uint32_t xcr0;
+#if defined(_MSC_VER)
+  xcr0 = (uint32_t)_xgetbv(0);
+#else
+  __asm__ ("xgetbv" : "=a" (xcr0) : "c" (0) : "%edx" );
+#endif
+  return ((xcr0 & 6) == 6);
+}
+
 /*
  * Class:     com_intel_gkl_IntelGKLUtils
  * Method:    isAvxSupportedNative
  * Signature: (Z)V
  */
-
 JNIEXPORT jboolean JNICALL Java_com_intel_gkl_IntelGKLUtils_isAvxSupportedNative
   (JNIEnv *env, jobject obj)
 {
-#if !defined(__clang__)
-  __builtin_cpu_init();
-#endif
-  volatile int r = __builtin_cpu_supports("avx");
-  return r ? true : false;
+  uint32_t abcd[4];
+  uint32_t avx_mask = (1 << 27) | (1 << 28);
+
+  run_cpuid(1, 0, abcd);
+  if((abcd[2] & avx_mask) != avx_mask) 
+  {
+    return false;
+  }
+
+  if(!check_xcr0_ymm())
+  {
+    return false;
+  }
+
+  return true;
 }
 
 /*


### PR DESCRIPTION
Changed AVX detection again to be compatible with Clang. Tested on Intel and AMD, as well as on OS X.