### PR TITLE
AVX detect fix gatk4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     compile 'org.broadinstitute:gatk-native-bindings:0.0.3'
     compile 'org.apache.logging.log4j:log4j-api:2.5'
     compile 'org.apache.logging.log4j:log4j-core:2.5'
-    compile 'org.apache.logging.log4j:log4j-1.2-api:2.5'
     compile 'com.github.samtools:htsjdk:2.9.0'
     testCompile 'org.testng:testng:6.9.9'
 }

--- a/src/main/java/com/intel/gkl/IntelGKLUtils.java
+++ b/src/main/java/com/intel/gkl/IntelGKLUtils.java
@@ -28,7 +28,8 @@
 
 package com.intel.gkl;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.gatk.nativebindings.NativeLibrary;
 
 import java.io.File;
@@ -38,7 +39,7 @@ import java.io.IOException;
  * Provides utilities used by the GKL library.
  */
 public final class IntelGKLUtils implements NativeLibrary {
-    private final static Logger logger = Logger.getLogger(IntelGKLUtils.class);
+    private final static Logger logger = LogManager.getLogger(IntelGKLUtils.class);
     private static final String NATIVE_LIBRARY_NAME = "gkl_utils";
     private static boolean initialized = false;
 

--- a/src/main/java/com/intel/gkl/NativeLibraryLoader.java
+++ b/src/main/java/com/intel/gkl/NativeLibraryLoader.java
@@ -2,7 +2,8 @@ package com.intel.gkl;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.net.URL;
@@ -13,7 +14,7 @@ import java.util.Set;
  * Loads native libraries from the classpath, usually from a jar file.
  */
 public final class NativeLibraryLoader {
-    private static final Logger logger = Logger.getLogger(NativeLibraryLoader.class);
+    private static final Logger logger = LogManager.getLogger(NativeLibraryLoader.class);
     private static final String USE_LIBRARY_PATH = "USE_LIBRARY_PATH";
     private static final Set<String> loadedLibraries = new HashSet<String>();
 

--- a/src/main/java/com/intel/gkl/compression/IntelDeflaterFactory.java
+++ b/src/main/java/com/intel/gkl/compression/IntelDeflaterFactory.java
@@ -1,7 +1,8 @@
 package com.intel.gkl.compression;
 
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.util.zip.Deflater;
@@ -10,7 +11,7 @@ import java.util.zip.Deflater;
  * Provides an IntelDeflater object using the DeflaterFactory API defined in HTSJDK
  */
 public class IntelDeflaterFactory extends DeflaterFactory {
-    private final static Logger logger = Logger.getLogger(IntelDeflaterFactory.class);
+    private final static Logger logger = LogManager.getLogger(IntelDeflaterFactory.class);
     private boolean intelDeflaterSupported;
 
     public IntelDeflaterFactory(File tmpDir) {

--- a/src/main/java/com/intel/gkl/compression/IntelInflaterFactory.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflaterFactory.java
@@ -2,7 +2,8 @@ package com.intel.gkl.compression;
 
 import htsjdk.samtools.util.zip.InflaterFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.util.zip.Inflater;
@@ -11,7 +12,7 @@ import java.util.zip.Inflater;
  * Created by pnvaidya on 2/1/17.
  */
 public class IntelInflaterFactory extends InflaterFactory {
-    private final static Logger logger = Logger.getLogger(IntelDeflaterFactory.class);
+    private final static Logger logger = LogManager.getLogger(IntelDeflaterFactory.class);
     private boolean intelInflaterSupported;
 
     public IntelInflaterFactory(File tmpDir) {

--- a/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
+++ b/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
@@ -1,6 +1,7 @@
 package com.intel.gkl.pairhmm;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.intel.gkl.IntelGKLUtils;
 import com.intel.gkl.NativeLibraryLoader;
@@ -15,7 +16,7 @@ import java.io.File;
  * Provides a native PairHMM implementation accelerated for the Intel Architecture.
  */
 public class IntelPairHmm implements PairHMMNativeBinding {
-    private final static Logger logger = Logger.getLogger(IntelPairHmm.class);
+    private final static Logger logger = LogManager.getLogger(IntelPairHmm.class);
     private static final String NATIVE_LIBRARY_NAME = "gkl_pairhmm";
     private String nativeLibraryName = "gkl_pairhmm";
     private IntelGKLUtils gklUtils = new IntelGKLUtils();

--- a/src/main/native/utils/utils.cc
+++ b/src/main/native/utils/utils.cc
@@ -42,7 +42,7 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_IntelGKLUtils_setFlushToZeroNative
 }
 
 // helper function
-static 
+static
 void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t* abcd)
 {
 #if defined(_MSC_VER)
@@ -58,11 +58,11 @@ void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t* abcd)
             "+a" (eax), "+c" (ecx), "=d" (edx) );
   abcd[0] = eax; abcd[1] = ebx; abcd[2] = ecx; abcd[3] = edx;
 #endif
-}     
+}
 
 // helper function
 static
-int check_xcr0_ymm() 
+int check_xcr0_ymm()
 {
   uint32_t xcr0;
 #if defined(_MSC_VER)
@@ -85,7 +85,7 @@ JNIEXPORT jboolean JNICALL Java_com_intel_gkl_IntelGKLUtils_isAvxSupportedNative
   uint32_t avx_mask = (1 << 27) | (1 << 28);
 
   run_cpuid(1, 0, abcd);
-  if((abcd[2] & avx_mask) != avx_mask) 
+  if((abcd[2] & avx_mask) != avx_mask)
   {
     return false;
   }

--- a/src/test/java/com/intel/gkl/IntelGKLUtilsUnitTest.java
+++ b/src/test/java/com/intel/gkl/IntelGKLUtilsUnitTest.java
@@ -1,12 +1,13 @@
 package com.intel.gkl;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.intel.gkl.pairhmm.IntelPairHmmOMP;
 
 public class IntelGKLUtilsUnitTest {
-    private final static Logger log = Logger.getLogger(IntelGKLUtilsUnitTest.class);
+    private final static Logger log = LogManager.getLogger(IntelGKLUtilsUnitTest.class);
 
     @Test(enabled = true)
     public void simpleTest() {

--- a/src/test/java/com/intel/gkl/compression/DeflaterIntegrationTest.java
+++ b/src/test/java/com/intel/gkl/compression/DeflaterIntegrationTest.java
@@ -3,7 +3,8 @@ package com.intel.gkl.compression;
 import com.intel.gkl.IntelGKLUtils;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -19,7 +20,7 @@ import java.util.zip.Deflater;
 public class
 DeflaterIntegrationTest {
 
-    private final static Logger log = Logger.getLogger(DeflaterIntegrationTest.class);
+    private final static Logger log = LogManager.getLogger(DeflaterIntegrationTest.class);
     private final static String INPUT_FILE = IntelGKLUtils.pathToTestResource("HiSeq.1mb.1RG.2k_lines.bam");
 
     @Test(enabled = true)

--- a/src/test/java/com/intel/gkl/compression/DeflaterProfile.java
+++ b/src/test/java/com/intel/gkl/compression/DeflaterProfile.java
@@ -3,7 +3,8 @@ package com.intel.gkl.compression;
 import com.intel.gkl.IntelGKLUtils;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -19,7 +20,7 @@ import java.util.zip.Deflater;
  */
 public class DeflaterProfile {
 
-    private final static Logger log = Logger.getLogger(DeflaterIntegrationTest.class);
+    private final static Logger log = LogManager.getLogger(DeflaterIntegrationTest.class);
     private final static String INPUT_FILE = IntelGKLUtils.pathToTestResource("HiSeq.1mb.1RG.2k_lines.bam");
 
     @Test(enabled = true)

--- a/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
+++ b/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
@@ -2,7 +2,8 @@ package com.intel.gkl.compression;
 
 import com.intel.gkl.IntelGKLUtils;
 import htsjdk.samtools.util.BlockCompressedInputStream;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -16,7 +17,7 @@ import java.util.zip.Inflater;
  */
 public class InflaterUnitTest {
 
-    private final static Logger log = Logger.getLogger(InflaterUnitTest.class);
+    private final static Logger log = LogManager.getLogger(InflaterUnitTest.class);
     private final static String INPUT_FILE = IntelGKLUtils.pathToTestResource("HiSeq.1mb.1RG.2k_lines.bam");
 
     @Test(enabled = true)


### PR DESCRIPTION
Fixes AVX detection for AMD machines. This branch is based on 0.5.5, which has the GATK4 style logging. Release 0.5.7 also fixes AVX detection, but is based on 0.5.6, which has GATK 3.x style logging.