### PR TITLE
Use pure log4j 1.x to stop gatk3 from complaining

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,12 @@ repositories {
 dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'org.broadinstitute:gatk-native-bindings:0.0.3'
-    compile 'org.apache.logging.log4j:log4j-api:2.5'
-    compile 'org.apache.logging.log4j:log4j-core:2.5'
-    compile 'org.apache.logging.log4j:log4j-1.2-api:2.5'
+    compile("log4j:log4j:1.2.15") {
+        exclude group: "com.sun.jdmk", module: "jmxtools"
+        exclude group: "com.sun.jmx", module: "jmxri"
+        exclude group: "javax.mail", module: "mail"
+        exclude group: "javax.jms", module: "jms"
+    }
     compile 'com.github.samtools:htsjdk:2.9.0'
     testCompile 'org.testng:testng:6.9.9'
 }

--- a/src/main/java/com/intel/gkl/IntelGKLUtils.java
+++ b/src/main/java/com/intel/gkl/IntelGKLUtils.java
@@ -28,8 +28,7 @@
 
 package com.intel.gkl;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 import org.broadinstitute.gatk.nativebindings.NativeLibrary;
 
 import java.io.File;
@@ -39,7 +38,7 @@ import java.io.IOException;
  * Provides utilities used by the GKL library.
  */
 public final class IntelGKLUtils implements NativeLibrary {
-    private final static Logger logger = LogManager.getLogger(IntelGKLUtils.class);
+    private final static Logger logger = Logger.getLogger(IntelGKLUtils.class);
     private static final String NATIVE_LIBRARY_NAME = "gkl_utils";
     private static boolean initialized = false;
 

--- a/src/main/java/com/intel/gkl/NativeLibraryLoader.java
+++ b/src/main/java/com/intel/gkl/NativeLibraryLoader.java
@@ -2,8 +2,7 @@ package com.intel.gkl;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.net.URL;
@@ -14,7 +13,7 @@ import java.util.Set;
  * Loads native libraries from the classpath, usually from a jar file.
  */
 public final class NativeLibraryLoader {
-    private static final Logger logger = LogManager.getLogger(NativeLibraryLoader.class);
+    private static final Logger logger = Logger.getLogger(NativeLibraryLoader.class);
     private static final String USE_LIBRARY_PATH = "USE_LIBRARY_PATH";
     private static final Set<String> loadedLibraries = new HashSet<String>();
 

--- a/src/main/java/com/intel/gkl/compression/IntelDeflaterFactory.java
+++ b/src/main/java/com/intel/gkl/compression/IntelDeflaterFactory.java
@@ -1,8 +1,7 @@
 package com.intel.gkl.compression;
 
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.zip.Deflater;
@@ -11,7 +10,7 @@ import java.util.zip.Deflater;
  * Provides an IntelDeflater object using the DeflaterFactory API defined in HTSJDK
  */
 public class IntelDeflaterFactory extends DeflaterFactory {
-    private final static Logger logger = LogManager.getLogger(IntelDeflaterFactory.class);
+    private final static Logger logger = Logger.getLogger(IntelDeflaterFactory.class);
     private boolean intelDeflaterSupported;
 
     public IntelDeflaterFactory(File tmpDir) {

--- a/src/main/java/com/intel/gkl/compression/IntelInflaterFactory.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflaterFactory.java
@@ -2,8 +2,7 @@ package com.intel.gkl.compression;
 
 import htsjdk.samtools.util.zip.InflaterFactory;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.zip.Inflater;
@@ -12,7 +11,7 @@ import java.util.zip.Inflater;
  * Created by pnvaidya on 2/1/17.
  */
 public class IntelInflaterFactory extends InflaterFactory {
-    private final static Logger logger = LogManager.getLogger(IntelDeflaterFactory.class);
+    private final static Logger logger = Logger.getLogger(IntelDeflaterFactory.class);
     private boolean intelInflaterSupported;
 
     public IntelInflaterFactory(File tmpDir) {

--- a/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
+++ b/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
@@ -1,7 +1,6 @@
 package com.intel.gkl.pairhmm;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 
 import com.intel.gkl.IntelGKLUtils;
 import com.intel.gkl.NativeLibraryLoader;
@@ -16,7 +15,7 @@ import java.io.File;
  * Provides a native PairHMM implementation accelerated for the Intel Architecture.
  */
 public class IntelPairHmm implements PairHMMNativeBinding {
-    private final static Logger logger = LogManager.getLogger(IntelPairHmm.class);
+    private final static Logger logger = Logger.getLogger(IntelPairHmm.class);
     private static final String NATIVE_LIBRARY_NAME = "gkl_pairhmm";
     private String nativeLibraryName = "gkl_pairhmm";
     private IntelGKLUtils gklUtils = new IntelGKLUtils();

--- a/src/test/java/com/intel/gkl/IntelGKLUtilsUnitTest.java
+++ b/src/test/java/com/intel/gkl/IntelGKLUtilsUnitTest.java
@@ -1,13 +1,12 @@
 package com.intel.gkl;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.intel.gkl.pairhmm.IntelPairHmmOMP;
 
 public class IntelGKLUtilsUnitTest {
-    private final static Logger log = LogManager.getLogger(IntelGKLUtilsUnitTest.class);
+    private final static Logger log = Logger.getLogger(IntelGKLUtilsUnitTest.class);
 
     @Test(enabled = true)
     public void simpleTest() {

--- a/src/test/java/com/intel/gkl/compression/DeflaterIntegrationTest.java
+++ b/src/test/java/com/intel/gkl/compression/DeflaterIntegrationTest.java
@@ -3,8 +3,7 @@ package com.intel.gkl.compression;
 import com.intel.gkl.IntelGKLUtils;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -20,7 +19,7 @@ import java.util.zip.Deflater;
 public class
 DeflaterIntegrationTest {
 
-    private final static Logger log = LogManager.getLogger(DeflaterIntegrationTest.class);
+    private final static Logger log = Logger.getLogger(DeflaterIntegrationTest.class);
     private final static String INPUT_FILE = IntelGKLUtils.pathToTestResource("HiSeq.1mb.1RG.2k_lines.bam");
 
     @Test(enabled = true)

--- a/src/test/java/com/intel/gkl/compression/DeflaterProfile.java
+++ b/src/test/java/com/intel/gkl/compression/DeflaterProfile.java
@@ -3,8 +3,7 @@ package com.intel.gkl.compression;
 import com.intel.gkl.IntelGKLUtils;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -20,7 +19,7 @@ import java.util.zip.Deflater;
  */
 public class DeflaterProfile {
 
-    private final static Logger log = LogManager.getLogger(DeflaterIntegrationTest.class);
+    private final static Logger log = Logger.getLogger(DeflaterIntegrationTest.class);
     private final static String INPUT_FILE = IntelGKLUtils.pathToTestResource("HiSeq.1mb.1RG.2k_lines.bam");
 
     @Test(enabled = true)

--- a/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
+++ b/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
@@ -2,8 +2,7 @@ package com.intel.gkl.compression;
 
 import com.intel.gkl.IntelGKLUtils;
 import htsjdk.samtools.util.BlockCompressedInputStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -17,7 +16,7 @@ import java.util.zip.Inflater;
  */
 public class InflaterUnitTest {
 
-    private final static Logger log = LogManager.getLogger(InflaterUnitTest.class);
+    private final static Logger log = Logger.getLogger(InflaterUnitTest.class);
     private final static String INPUT_FILE = IntelGKLUtils.pathToTestResource("HiSeq.1mb.1RG.2k_lines.bam");
 
     @Test(enabled = true)


### PR DESCRIPTION
It was necessary to use pure log4j 1.x, as opposed to log4j2 with the log4j2-1.2-api bridge package in order for this to work with GATK 3.x.

This branch is based on 0.5.7, so it also includes the AVX detection fixes included there.