### PR TITLE
Core dump bug fix for GATK3.8

### DIFF
--- a/src/main/native/compression/IntelDeflater.cc
+++ b/src/main/native/compression/IntelDeflater.cc
@@ -256,7 +256,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
 
     // set finished if endOfStream was set and all input processed
     if (endOfStream && lz_stream->avail_in == 0) {
-      env->SetLongField(obj, FID_finished, true);
+      env->SetBooleanField(obj, FID_finished, true);
     }
 
     // return number of bytes written to output buffer
@@ -299,7 +299,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
     env->ReleasePrimitiveArrayCritical(outputBuffer, next_out, 0);
 
     if (ret == Z_STREAM_END && lz_stream->avail_in == 0) { 
-      env->SetLongField(obj, FID_finished, true);
+      env->SetBooleanField(obj, FID_finished, true);
     }
 
     return bytes_out;

--- a/src/main/native/compression/IntelInflater.cc
+++ b/src/main/native/compression/IntelInflater.cc
@@ -151,7 +151,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
         env->ReleasePrimitiveArrayCritical(outputBuffer, next_out, 0);
 
         if (ret == ISAL_END_INPUT && lz_stream->avail_in == 0) {
-          env->SetLongField(obj, FID_inf_finished, true);
+          env->SetBooleanField(obj, FID_inf_finished, true);
         }
 
         return bytes_out;


### PR DESCRIPTION
SetField mismatch error fixed in Native code, removed the core dump issue reported in GATK 3.8 release. 