### PR TITLE
Change FTZ log message from warning to info

### DIFF
--- a/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
+++ b/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
@@ -76,7 +76,7 @@ public class IntelPairHmm implements PairHMMNativeBinding {
         }
 
         if(!gklUtils.getFlushToZero()) {
-            logger.warn("Flush-to-zero (FTZ) is enabled when running PairHMM");
+            logger.info("Flush-to-zero (FTZ) is enabled when running PairHMM");
         }
 
         initNative(ReadDataHolder.class, HaplotypeDataHolder.class, args.useDoublePrecision, args.maxNumberOfThreads, useFpga);


### PR DESCRIPTION
* Changing the log message "Flush-to-zero (FTZ) is enabled when running PairHMM" from being a warning to an info message.
* Part of https://github.com/broadinstitute/gatk/issues/5393