### PR TITLE
update gatk-native-bindings dependency to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     compile 'commons-io:commons-io:2.4'
-    compile 'org.broadinstitute:gatk-native-bindings:0.1.0-rc-1'
+    compile 'org.broadinstitute:gatk-native-bindings:1.0.0'
     compile 'org.apache.logging.log4j:log4j-api:2.5'
     compile 'org.apache.logging.log4j:log4j-core:2.5'
     compile 'com.github.samtools:htsjdk:2.9.0'


### PR DESCRIPTION
* This is a cosmetic change, 0.1.0-rc-1 was r-released as 1.0.0 once we verified it was ok.  It looks less weird to use the release version though.