### PR TITLE
AEJ - 1607 Common cflags for native lib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ if(APPLE)
 elseif(UNIX)
   set(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++ -static-libgcc")
 endif()
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,now")
 
 # add CMakeLists.txt in subdirectories
 set(NATIVE_DIR ${PROJECT_SOURCE_DIR}/src/main/native)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,12 @@ find_package(JNI)
 include_directories(${JNI_INCLUDE_DIRS})
 
 # common compiler and linker settings
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Werror=format-security")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv")
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if(APPLE)
   set(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++")


### PR DESCRIPTION
Changes for cflags includes

- removing `-g`  debugging flag 
- added unformmated string security flags `-Wformat -Werror=format-security`
- stack overflow `-D_FORTIFY_SOURCE=2 -fstack-protector-all`
- helper flags override disbaled by optimization flags `-fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv`
- immediate binding flags  `-Wl now`
