### PR TITLE
AEJ-1584 - Fix JNI Exception handling mechanism in GKL

### DIFF
--- a/src/main/java/com/intel/gkl/compression/IntelInflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflater.java
@@ -28,6 +28,9 @@
 
 package com.intel.gkl.compression;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.intel.gkl.NativeLibraryLoader;
 import org.broadinstitute.gatk.nativebindings.NativeLibrary;
 
@@ -38,6 +41,7 @@ import java.util.zip.Inflater;
  * Provides a native Inflater implementation accelerated for the Intel Architecture.
  */
 public final class IntelInflater extends Inflater implements NativeLibrary {
+    private static final Logger logger = LogManager.getLogger(IntelInflater.class);
     private static final String NATIVE_LIBRARY_NAME = "gkl_compression";
     private static boolean initialized = false;
 
@@ -96,8 +100,14 @@ public final class IntelInflater extends Inflater implements NativeLibrary {
     }
 
     @Override
-    public void reset() {
-        resetNative(nowrap);
+    public void reset() throws OutOfMemoryError {
+        try {
+            resetNative(nowrap);
+        } catch (OutOfMemoryError e) {
+            logger.warn("Exception thrown from native Inflater resetNative function call %s", e.getMessage());
+            throw new OutOfMemoryError("Memory allocation failed");
+        }
+
         inputBuffer = null;
         inputBufferLength = 0;
         finished = false;

--- a/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
+++ b/src/main/java/com/intel/gkl/pairhmm/IntelPairHmm.java
@@ -106,12 +106,21 @@ public class IntelPairHmm implements PairHMMNativeBinding {
     @Override
     public void computeLikelihoods(ReadDataHolder[] readDataArray,
                                    HaplotypeDataHolder[] haplotypeDataArray,
-                                   double[] likelihoodArray) throws NullPointerException
+                                   double[] likelihoodArray) throws NullPointerException, OutOfMemoryError, IllegalArgumentException
     {
         if(readDataArray == null || haplotypeDataArray == null || likelihoodArray == null) {
             throw new NullPointerException("Input is null");
         }
-        computeLikelihoodsNative(readDataArray, haplotypeDataArray, likelihoodArray);
+        try {
+            computeLikelihoodsNative(readDataArray, haplotypeDataArray, likelihoodArray);
+        } catch (OutOfMemoryError e) {
+            logger.warn("Exception thrown from native PairHMM computeLikelihoodsNative function call %s", e.getMessage());
+            throw new OutOfMemoryError("Memory allocation failed");
+        } catch (IllegalArgumentException e) {
+            logger.warn("Exception thrown from native PairHMM computeLikelihoodsNative function call %s", e.getMessage());
+            throw new IllegalArgumentException("Ran into invalid argument issue");
+        }
+
     }
 
     /**

--- a/src/main/native/compression/IntelDeflater.cc
+++ b/src/main/native/compression/IntelDeflater.cc
@@ -90,10 +90,8 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelDeflater_resetNative
     if (lz_stream == 0) {
       lz_stream = (isal_zstream*)malloc(sizeof(isal_zstream));
       if ( lz_stream == NULL ) {
-
         if(env->ExceptionCheck())
             env->ExceptionClear();
-
         env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
       }
 
@@ -124,10 +122,8 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelDeflater_resetNative
     if (lz_stream == 0) {
       lz_stream = (z_stream*)calloc(1, sizeof(z_stream));
       if ( lz_stream == NULL ) {
-
         if(env->ExceptionCheck())
             env->ExceptionClear();
-
         env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
       }
       env->SetLongField(obj, FID_lz_stream, (jlong)lz_stream);
@@ -139,10 +135,8 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelDeflater_resetNative
                              nowrap ? -MAX_WBITS : MAX_WBITS,
                              DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
       if (ret != Z_OK) {
-
         if(env->ExceptionCheck())
             env->ExceptionClear();
-
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"),"IntelDeflater init error");
       }
     }

--- a/src/main/native/compression/IntelDeflater.cc
+++ b/src/main/native/compression/IntelDeflater.cc
@@ -90,8 +90,11 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelDeflater_resetNative
     if (lz_stream == 0) {
       lz_stream = (isal_zstream*)malloc(sizeof(isal_zstream));
       if ( lz_stream == NULL ) {
-        jclass Exception = env->FindClass("java/lang/Exception");
-        env->ThrowNew(Exception,"Memory allocation error");
+
+        if(env->ExceptionCheck())
+            env->ExceptionClear();
+
+        env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
       }
 
       env->SetLongField(obj, FID_lz_stream, (jlong)lz_stream);
@@ -121,8 +124,11 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelDeflater_resetNative
     if (lz_stream == 0) {
       lz_stream = (z_stream*)calloc(1, sizeof(z_stream));
       if ( lz_stream == NULL ) {
-        jclass Exception = env->FindClass("java/lang/Exception");
-        env->ThrowNew(Exception,"Memory allocation error");
+
+        if(env->ExceptionCheck())
+            env->ExceptionClear();
+
+        env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
       }
       env->SetLongField(obj, FID_lz_stream, (jlong)lz_stream);
       
@@ -133,8 +139,11 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelDeflater_resetNative
                              nowrap ? -MAX_WBITS : MAX_WBITS,
                              DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
       if (ret != Z_OK) {
-        jclass Exception = env->FindClass("java/lang/Exception");
-        env->ThrowNew(Exception,"IntelDeflater init error");
+
+        if(env->ExceptionCheck())
+            env->ExceptionClear();
+
+        env->ThrowNew(env->FindClass("java/lang/RuntimeException"),"IntelDeflater init error");
       }
     }
     else {

--- a/src/main/native/compression/IntelInflater.cc
+++ b/src/main/native/compression/IntelInflater.cc
@@ -78,8 +78,11 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelInflater_resetNative
 
      lz_stream = (inflate_state*)calloc(1,sizeof(inflate_state));
       if ( lz_stream == NULL ) {
-        jclass Exception = env->FindClass("java/lang/Exception");
-        env->ThrowNew(Exception,"Memory allocation error");
+
+        if(env->ExceptionCheck())
+            env->ExceptionClear();
+
+        env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
       }
       env->SetLongField(obj, FID_inf_lz_stream, (jlong)lz_stream);
 

--- a/src/main/native/compression/IntelInflater.cc
+++ b/src/main/native/compression/IntelInflater.cc
@@ -78,10 +78,8 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelInflater_resetNative
 
      lz_stream = (inflate_state*)calloc(1,sizeof(inflate_state));
       if ( lz_stream == NULL ) {
-
         if(env->ExceptionCheck())
             env->ExceptionClear();
-
         env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
       }
       env->SetLongField(obj, FID_inf_lz_stream, (jlong)lz_stream);

--- a/src/main/native/pairhmm/JavaData.h
+++ b/src/main/native/pairhmm/JavaData.h
@@ -84,7 +84,7 @@ class JavaData {
   static jfieldID getFieldId(JNIEnv *env, jclass clazz, const char *name, const char *sig) {
     jfieldID id = env->GetFieldID(clazz, name, sig);
     if (id == NULL) {
-      env->ThrowNew(env->FindClass("java/lang/Exception"), "Unable to get field ID"); 
+      env->ThrowNew(env->FindClass("java/lang/IllegalArgumentException"), "Unable to get field ID");
     }
     return id;
   }

--- a/src/main/native/smithwaterman/IntelSmithWaterman.cc
+++ b/src/main/native/smithwaterman/IntelSmithWaterman.cc
@@ -72,6 +72,15 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_smithwaterman_IntelSmithWaterman_align
     env->ReleasePrimitiveArrayCritical(alt, alternate, 0);
     env->ReleasePrimitiveArrayCritical(cigar, cigarArray, 0);
 
+    if(offset == -1 || env->ExceptionCheck()) {
+        env->ExceptionClear();
+        env->ThrowNew(env->FindClass("java/lang/IllegalArgumentException"), "Invalid offset value");
+    }
+
+    if(offset == -2) {
+        env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"), "Memory allocation issue");
+    }
+
     return offset;
 }
 

--- a/src/main/native/smithwaterman/PairWiseSW.h
+++ b/src/main/native/smithwaterman/PairWiseSW.h
@@ -427,20 +427,20 @@ int32_t CONCAT(runSWOnePairBT_,SIMD_ENGINE)(int32_t match, int32_t mismatch, int
     int32_t  w_open = open;
     int32_t  w_extend = extend;
 
+    int len = max(len1, len2);
+    if(len >  MAX_SEQ_LEN) {
+             return -1;
+    }
+
     int32_t  *E_  = (int32_t *)_mm_malloc((6 * (MAX_SEQ_LEN+ AVX_LENGTH)) * sizeof(int32_t), 64);
     int16_t  *backTrack_ = (int16_t *)_mm_malloc((2 * MAX_SEQ_LEN * MAX_SEQ_LEN + 2 * AVX_LENGTH) * sizeof(int16_t), 64);
     int16_t  *cigarBuf_  = (int16_t *)_mm_malloc(4 * MAX_SEQ_LEN * sizeof(int16_t), 64);
 
-    int len = max(len1, len2);
-    if(len >  MAX_SEQ_LEN) {
-             return -1;
-        }
-	
     if (E_ == NULL  || backTrack_  == NULL || cigarBuf_ == NULL) {
          _mm_free(E_);
          _mm_free(backTrack_);
          _mm_free(cigarBuf_);
-	 return -1; 
+	 return -2;
     } 
 
     SeqPair p;


### PR DESCRIPTION
AEJ-1584 - Fix JNI Exception handling mechanism in GKL for Deflater, Inflater, PairHMM and SmithWaterman native classes and handle new exceptions propagated from corresponding native code in C classes. 
