### PR TITLE
AEJ-2445 AEJ-2446: Handle native compression errors

### DIFF
--- a/src/main/native/compression/IntelDeflater.cc
+++ b/src/main/native/compression/IntelDeflater.cc
@@ -283,9 +283,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
              (double) (tv2.tv_sec - tv1.tv_sec));
 #endif
 
-    long bytes_out = outputBufferLength - lz_stream->avail_out;
 
-     DBG ("bytes_out = %d \n", bytes_out);
       DBG ("avail_out = %d \n",lz_stream->avail_out );
 
 
@@ -321,9 +319,12 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
 
       env->ExceptionClear();
       env->ThrowNew(env->FindClass("java/lang/RuntimeException"), msg);
+      return -1;
     }
 
     // return number of bytes written to output buffer
+    long bytes_out = outputBufferLength - lz_stream->avail_out;
+    DBG ("bytes_out = %d \n", bytes_out);
     return bytes_out;
   }
   else {
@@ -379,8 +380,6 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
               (double) (tv2.tv_sec - tv1.tv_sec));
  #endif
 
-    int bytes_out = outputBufferLength - lz_stream->avail_out;
-
     // release buffers
     env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
     env->ReleasePrimitiveArrayCritical(outputBuffer, next_out, 0);
@@ -404,8 +403,10 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
 
       env->ExceptionClear();
       env->ThrowNew(env->FindClass("java/lang/RuntimeException"), msg);
+      return -1;
     }
 
+    int bytes_out = outputBufferLength - lz_stream->avail_out;
     return bytes_out;
   }
 }

--- a/src/main/native/compression/IntelInflater.cc
+++ b/src/main/native/compression/IntelInflater.cc
@@ -161,7 +161,6 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
          (double) (tv2.tv_usec - tv1.tv_usec) / 1000000 +
          (double) (tv2.tv_sec - tv1.tv_sec));
 #endif
-         int bytes_out = outputBufferLength - lz_stream->avail_out;
 
 
         DBG("%s", lz_stream->msg);
@@ -210,10 +209,11 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
 
           env->ExceptionClear();
           env->ThrowNew(env->FindClass("java/lang/RuntimeException"), msg);
+          return -1;
         }
 
+        int bytes_out = outputBufferLength - lz_stream->avail_out;
         return bytes_out;
-
 }
 
 /*

--- a/src/main/native/compression/IntelInflater.cc
+++ b/src/main/native/compression/IntelInflater.cc
@@ -174,13 +174,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
         env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
         env->ReleasePrimitiveArrayCritical(outputBuffer, next_out, 0);
 
-        /*
-        As far as I can tell this block never gets triggered as ISAL_END_INPUT
-        isn't listed as a possible return of isal_inflate(). I don't have a good
-        understanding of how this value is being used by the Java class but this
-        should either be fixed or removed.
-        */
-        if (ret == ISAL_END_INPUT && lz_stream->avail_in == 0) {
+        if (ret == ISAL_DECOMP_OK && lz_stream->avail_in == 0) {
           env->SetBooleanField(obj, FID_inf_finished, true);
         }
 

--- a/src/main/native/compression/IntelInflater.cc
+++ b/src/main/native/compression/IntelInflater.cc
@@ -174,8 +174,48 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
         env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
         env->ReleasePrimitiveArrayCritical(outputBuffer, next_out, 0);
 
+        /*
+        As far as I can tell this block never gets triggered as ISAL_END_INPUT
+        isn't listed as a possible return of isal_inflate(). I don't have a good
+        understanding of how this value is being used by the Java class but this
+        should either be fixed or removed.
+        */
         if (ret == ISAL_END_INPUT && lz_stream->avail_in == 0) {
           env->SetBooleanField(obj, FID_inf_finished, true);
+        }
+
+        if (ret != ISAL_DECOMP_OK) {
+          const char* msg;
+
+          switch (ret) {
+            case ISAL_INVALID_BLOCK:
+              msg = "Invalid deflate block found.";
+              break;
+            case ISAL_NEED_DICT:
+              msg = "Stream needs a dictionary to continue.";
+              break;
+            case ISAL_INVALID_SYMBOL:
+              msg = "Invalid deflate symbol found.";
+              break;
+            case ISAL_INVALID_LOOKBACK:
+              msg = "Invalid lookback distance found.";
+              break;
+            case ISAL_INVALID_WRAPPER:
+              msg = "Invalid gzip/zlib wrapper found.";
+              break;
+            case ISAL_UNSUPPORTED_METHOD:
+              msg = "Gzip/zlib wrapper specifies unsupported compress method.";
+              break;
+            case ISAL_INCORRECT_CHECKSUM:
+              msg = "Incorrect checksum found.";
+              break;
+            default:
+              msg = "isal_inflate returned an unknown return code.";
+              DBG("lsal_inflate returned %d", ret);
+          }
+
+          env->ExceptionClear();
+          env->ThrowNew(env->FindClass("java/lang/RuntimeException"), msg);
         }
 
         return bytes_out;


### PR DESCRIPTION
This propagates all the errors that may be generated by the compression libraries to the Java layer.