### PR TITLE
Remove Zlib compression support

### DIFF
--- a/src/main/java/com/intel/gkl/compression/IntelDeflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelDeflater.java
@@ -93,6 +93,11 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
         if ((level < 0 || level > 9) && level != DEFAULT_COMPRESSION) {
             throw new IllegalArgumentException("Illegal compression level");
         }
+
+	if(nowrap == false) {
+		 throw new IllegalArgumentException("ZLIB format is not supported at this time with Intel GKL");
+	}
+	    
         this.level = level;
         this.nowrap = nowrap;
         strategy = DEFAULT_STRATEGY;
@@ -105,7 +110,7 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
      * @param level the compression level (0-9)
      */
     public IntelDeflater(int level) {
-        this(level, false);
+        this(level, true);
     }
 
     /**
@@ -113,7 +118,7 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
      * Compressed data will be generated in ZLIB format.
      */
     public IntelDeflater() {
-        this(DEFAULT_COMPRESSION, false);
+        this(DEFAULT_COMPRESSION, true);
     }
 
     @Override

--- a/src/main/java/com/intel/gkl/compression/IntelInflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflater.java
@@ -87,8 +87,11 @@ public final class IntelInflater extends Inflater implements NativeLibrary {
      * @param nowrap if true then use GZIP compatible compression
      */
     public IntelInflater(boolean nowrap) {
-      //  initFieldsNative();
-        this.nowrap = nowrap;
+	if(nowrap == false) {
+		 throw new IllegalArgumentException("ZLIB format is not supported at this time with Intel GKL");
+	}
+	    
+	this.nowrap = nowrap;
 
     }
 
@@ -97,7 +100,7 @@ public final class IntelInflater extends Inflater implements NativeLibrary {
      * Compressed data will be generated in ZLIB format.
      */
     public IntelInflater() {
-        this(false);
+        this(true);
     }
 
     @Override


### PR DESCRIPTION
Support GZIP compression for only now.  

Signed-off-by: keith.mannthey@intel.com