### PR TITLE
AEJ-1617 Prevent Smith-Waterman from integer overflow

### DIFF
--- a/src/main/java/com/intel/gkl/smithwaterman/IntelSmithWaterman.java
+++ b/src/main/java/com/intel/gkl/smithwaterman/IntelSmithWaterman.java
@@ -30,7 +30,10 @@ public class IntelSmithWaterman implements SWAlignerNativeBinding {
     private String nativeLibraryName = "gkl_smithwaterman";
     private static boolean initialized = false;
     private IntelGKLUtils gklUtils = new IntelGKLUtils();
+
+    // limited due to the internal implementation of the native code in C
     private final int MAX_SEQUENCE_LENGTH = 32*1024-1; // 2^15 - 1
+    // prevents integer overflow on the diagonal of the scoring matrix
     private final int MAXIMUM_MATCH_VALUE = 64*1024; // 2^16
 
     void setNativeLibraryName(String nativeLibraryName) {

--- a/src/main/java/com/intel/gkl/smithwaterman/IntelSmithWaterman.java
+++ b/src/main/java/com/intel/gkl/smithwaterman/IntelSmithWaterman.java
@@ -30,6 +30,8 @@ public class IntelSmithWaterman implements SWAlignerNativeBinding {
     private String nativeLibraryName = "gkl_smithwaterman";
     private static boolean initialized = false;
     private IntelGKLUtils gklUtils = new IntelGKLUtils();
+    private final int MAX_SEQUENCE_LENGTH = 32*1024-1; // 2^15 - 1
+    private final int MAXIMUM_MATCH_VALUE = 64*1024; // 2^16
 
     void setNativeLibraryName(String nativeLibraryName) {
         this.nativeLibraryName = nativeLibraryName;
@@ -108,6 +110,13 @@ public class IntelSmithWaterman implements SWAlignerNativeBinding {
 
         int intStrategy =  getStrategy(overhangStrategy);
         byte[] cigar = new byte[2*Integer.max(refArray.length, altArray.length)];
+
+        if(refArray.length > MAX_SEQUENCE_LENGTH || altArray.length > MAX_SEQUENCE_LENGTH){
+            throw new IllegalArgumentException(String.format("Sequences exceed maximum length of %d bytes", MAX_SEQUENCE_LENGTH));
+        }
+        if(parameters.getMatchValue() > MAXIMUM_MATCH_VALUE){
+            throw new IllegalArgumentException(String.format("Match value parameter exceed maximum value of %d", MAXIMUM_MATCH_VALUE));
+        }
 
         if(cigar.length <= 0 || intStrategy < 9 || intStrategy > 12)
             throw new IllegalArgumentException("Strategy is invalid.");

--- a/src/main/java/com/intel/gkl/smithwaterman/IntelSmithWaterman.java
+++ b/src/main/java/com/intel/gkl/smithwaterman/IntelSmithWaterman.java
@@ -9,15 +9,9 @@ import org.broadinstitute.gatk.nativebindings.smithwaterman.SWParameters;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWAlignerNativeBinding;
 
-import htsjdk.samtools.Cigar;
-import htsjdk.samtools.CigarElement;
-import htsjdk.samtools.CigarOperator;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWNativeAlignerResult;
 
 import java.io.File;
-import java.lang.Object;
-import java.nio.charset.Charset;
-import java.util.Arrays;
 
 /**
  * Provides a native SmithWaterman implementation accelerated for the Intel Architecture.
@@ -32,9 +26,9 @@ public class IntelSmithWaterman implements SWAlignerNativeBinding {
     private IntelGKLUtils gklUtils = new IntelGKLUtils();
 
     // limited due to the internal implementation of the native code in C
-    private final int MAX_SEQUENCE_LENGTH = 32*1024-1; // 2^15 - 1
+    private final int MAX_SW_SEQUENCE_LENGTH = 32*1024-1; // 2^15 - 1
     // prevents integer overflow on the diagonal of the scoring matrix
-    private final int MAXIMUM_MATCH_VALUE = 64*1024; // 2^16
+    private final int MAXIMUM_SW_MATCH_VALUE = 64*1024; // 2^16
 
     void setNativeLibraryName(String nativeLibraryName) {
         this.nativeLibraryName = nativeLibraryName;
@@ -114,11 +108,11 @@ public class IntelSmithWaterman implements SWAlignerNativeBinding {
         int intStrategy =  getStrategy(overhangStrategy);
         byte[] cigar = new byte[2*Integer.max(refArray.length, altArray.length)];
 
-        if(refArray.length > MAX_SEQUENCE_LENGTH || altArray.length > MAX_SEQUENCE_LENGTH){
-            throw new IllegalArgumentException(String.format("Sequences exceed maximum length of %d bytes", MAX_SEQUENCE_LENGTH));
+        if(refArray.length > MAX_SW_SEQUENCE_LENGTH || altArray.length > MAX_SW_SEQUENCE_LENGTH){
+            throw new IllegalArgumentException(String.format("Sequences exceed maximum length of %d bytes", MAX_SW_SEQUENCE_LENGTH));
         }
-        if(parameters.getMatchValue() > MAXIMUM_MATCH_VALUE){
-            throw new IllegalArgumentException(String.format("Match value parameter exceed maximum value of %d", MAXIMUM_MATCH_VALUE));
+        if(parameters.getMatchValue() > MAXIMUM_SW_MATCH_VALUE){
+            throw new IllegalArgumentException(String.format("Match value parameter exceed maximum value of %d", MAXIMUM_SW_MATCH_VALUE));
         }
 
         if(cigar.length <= 0 || intStrategy < 9 || intStrategy > 12)

--- a/src/main/native/smithwaterman/PairWiseSW.h
+++ b/src/main/native/smithwaterman/PairWiseSW.h
@@ -36,7 +36,7 @@
             VEC_STOREU((VEC_INT_TYPE *)(&H[hCurInd]), h11); \
             }
 
-static int D_MAX_SEQ_LEN = MAX_SEQ_LEN;
+static uint32_t D_MAX_SEQ_LEN = MAX_SEQ_LEN;
 
 void inline smithWatermanBackTrack(SeqPair *p, int32_t match, int32_t mismatch, int32_t open, int32_t extend, int32_t* E_,int32_t tid)
 {
@@ -428,13 +428,13 @@ int32_t CONCAT(runSWOnePairBT_,SIMD_ENGINE)(int32_t match, int32_t mismatch, int
     int32_t  w_open = open;
     int32_t  w_extend = extend;
 
+    
+    D_MAX_SEQ_LEN = MAX_SEQ_LEN;
+
     int len = max(len1, len2);
-    if(len > MAX_SEQ_LEN) {
-	while(len > D_MAX_SEQ_LEN)
-	   D_MAX_SEQ_LEN = 2*D_MAX_SEQ_LEN;
-    }
-    else{
-	D_MAX_SEQ_LEN = MAX_SEQ_LEN;
+
+    while(len >= D_MAX_SEQ_LEN){
+	        D_MAX_SEQ_LEN += 1024;
     }
 
     int32_t  *E_  = (int32_t *)_mm_malloc((6 * (D_MAX_SEQ_LEN+ AVX_LENGTH)) * sizeof(int32_t), 64);

--- a/src/main/native/smithwaterman/PairWiseSW.h
+++ b/src/main/native/smithwaterman/PairWiseSW.h
@@ -434,7 +434,7 @@ int32_t CONCAT(runSWOnePairBT_,SIMD_ENGINE)(int32_t match, int32_t mismatch, int
     int len = max(len1, len2);
 
     while(len >= D_MAX_SEQ_LEN){
-	        D_MAX_SEQ_LEN += 1024;
+	        D_MAX_SEQ_LEN += MAX_SEQ_LEN;
     }
 
     int32_t  *E_  = (int32_t *)_mm_malloc((6 * (D_MAX_SEQ_LEN+ AVX_LENGTH)) * sizeof(int32_t), 64);

--- a/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
+++ b/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
@@ -72,6 +72,47 @@ public class SmithWatermanUnitTest {
         }
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void smithWatermanThrowsIllegalArgumentExceptionIfRefSequenceLengthTooLong(){
+        final IntelSmithWaterman sw = new IntelSmithWaterman();
+        int sequenceLength = TestingUtils.MAX_SW_SEQUENCE_LENGTH+1;
+
+        byte[] ref = TestingUtils.generateRandomDNAArray(sequenceLength);
+        byte[] align = new byte[]{'T', 'C', 'C', 'G'};
+
+        SWParameters SWparameters = new SWParameters(10, -5, -10, -10);
+        sw.align(ref, align, SWparameters, SWOverhangStrategy.IGNORE);
+
+        Assert.fail();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void smithWatermanThrowsIllegalArgumentExceptionIfAlignSequenceLengthTooLong(){
+        final IntelSmithWaterman sw = new IntelSmithWaterman();
+        int sequenceLength = TestingUtils.MAX_SW_SEQUENCE_LENGTH+1;
+
+        byte[] ref = new byte[]{'T', 'C', 'C', 'G'};
+        byte[] align = TestingUtils.generateRandomDNAArray(sequenceLength);
+
+        SWParameters SWparameters = new SWParameters(10, -5, -10, -10);
+        sw.align(ref, align, SWparameters, SWOverhangStrategy.IGNORE);
+
+        Assert.fail();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void smithWatermanThrowsIllegalArgumentExceptionIfMatchValueGreaterThanMaxAllowed(){
+        final IntelSmithWaterman sw = new IntelSmithWaterman();
+        int matchValue = TestingUtils.MAX_SW_MATCH_VALUE + 1;
+        byte[] ref = new byte[]{'A', 'C', 'C', 'G'};
+        byte[] align = new byte[]{'T', 'C', 'C', 'G'};
+
+        SWParameters SWparameters = new SWParameters(matchValue, -5, -10, -10);
+        sw.align(ref, align, SWparameters, SWOverhangStrategy.IGNORE);
+
+        Assert.fail();
+    }
+    
     @Test(enabled = true)
     public void maxSequenceFullAlignmentTest(){
         final IntelSmithWaterman smithWaterman = new IntelSmithWaterman();

--- a/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
+++ b/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
@@ -1,6 +1,5 @@
 package com.intel.gkl.smithwaterman;
 
-import com.intel.gkl.smithwaterman.IntelSmithWaterman;
 import com.intel.gkl.IntelGKLUtils;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWParameters;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
@@ -10,6 +9,9 @@ import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.io.*;
+import java.util.Arrays;
+import java.util.Random;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -18,7 +20,6 @@ public class SmithWatermanUnitTest {
     private final static Logger logger = LogManager.getLogger(SmithWatermanUnitTest.class);
 
     static final String smithwatermanData = IntelGKLUtils.pathToTestResource("smith-waterman.SOFTCLIP.in");
-    int MAX_SEQ_LEN = 1024;
 
     @Test(enabled = true)
     public void inputDataTest() {
@@ -69,6 +70,38 @@ public class SmithWatermanUnitTest {
             e.printStackTrace();
         }
     }
+    public byte[] randomDNA(int len) {
+        Random rng = new Random();
+        final byte[] DNA_CHARS = {'A', 'C', 'G', 'T'};
+        byte[] array = new byte[len];
+        for (int i = 0; i < array.length; i++) {
+            array[i] = DNA_CHARS[rng.nextInt(DNA_CHARS.length)];
+        }
+        return array;
+    }
+
+    // MAX SEQUENCE LENGTH = 2^15 -1
+    // MAX MATCH VALUE = 2^16 + 2
+    @Test
+    public void maxSequenceFullAlignmentTest(){
+        final IntelSmithWaterman smithWaterman = new IntelSmithWaterman();
+        final boolean isLoaded = smithWaterman.load(null);
+        
+        if(!isLoaded) throw new SkipException("Could not load IntelSmithWaterman; skipping test...");
+
+        int matchValue =64*1024;
+        int sequenceLength = 32*1024-1;
+
+        String expectedCigar = String.format("%dM", sequenceLength);
+
+        byte[] ref = randomDNA(sequenceLength);
+        byte[] align = Arrays.copyOf(ref, ref.length);
+
+        SWParameters SWparameters = new SWParameters(matchValue, -5, -10, -10);
+        SWNativeAlignerResult result = smithWaterman.align(ref, align, SWparameters, SWOverhangStrategy.IGNORE);
+
+        Assert.assertEquals(result.cigar, expectedCigar);
+    }
 
     @Test(enabled = true)
     public void simpleTest() {
@@ -85,9 +118,7 @@ public class SmithWatermanUnitTest {
         }
 
         try {
-
             final File inputFile = new File(smithwatermanData);
-            long inputBytes = inputFile.length();
             final FileReader input = new FileReader(inputFile);
             final BufferedReader in = new BufferedReader(input);
 

--- a/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
+++ b/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
@@ -1,6 +1,7 @@
 package com.intel.gkl.smithwaterman;
 
 import com.intel.gkl.IntelGKLUtils;
+import com.intel.gkl.testing_utils.TestingUtils;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWParameters;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWNativeAlignerResult;
@@ -70,31 +71,20 @@ public class SmithWatermanUnitTest {
             e.printStackTrace();
         }
     }
-    public byte[] randomDNA(int len) {
-        Random rng = new Random();
-        final byte[] DNA_CHARS = {'A', 'C', 'G', 'T'};
-        byte[] array = new byte[len];
-        for (int i = 0; i < array.length; i++) {
-            array[i] = DNA_CHARS[rng.nextInt(DNA_CHARS.length)];
-        }
-        return array;
-    }
 
-    // MAX SEQUENCE LENGTH = 2^15 -1
-    // MAX MATCH VALUE = 2^16 + 2
-    @Test
+    @Test(enabled = true)
     public void maxSequenceFullAlignmentTest(){
         final IntelSmithWaterman smithWaterman = new IntelSmithWaterman();
         final boolean isLoaded = smithWaterman.load(null);
         
         if(!isLoaded) throw new SkipException("Could not load IntelSmithWaterman; skipping test...");
 
-        int matchValue =64*1024;
-        int sequenceLength = 32*1024-1;
+        int matchValue = TestingUtils.MAX_SW_MATCH_VALUE;
+        int sequenceLength = TestingUtils.MAX_SW_SEQUENCE_LENGTH;
 
         String expectedCigar = String.format("%dM", sequenceLength);
 
-        byte[] ref = randomDNA(sequenceLength);
+        byte[] ref = TestingUtils.generateRandomDNAArray(sequenceLength);
         byte[] align = Arrays.copyOf(ref, ref.length);
 
         SWParameters SWparameters = new SWParameters(matchValue, -5, -10, -10);

--- a/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
+++ b/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
@@ -11,7 +11,6 @@ import org.testng.annotations.Test;
 
 import java.io.*;
 import java.util.Arrays;
-import java.util.Random;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -112,7 +111,7 @@ public class SmithWatermanUnitTest {
 
         Assert.fail();
     }
-    
+
     @Test(enabled = true)
     public void maxSequenceFullAlignmentTest(){
         final IntelSmithWaterman smithWaterman = new IntelSmithWaterman();

--- a/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
+++ b/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
@@ -148,7 +148,9 @@ public class SmithWatermanUnitTest {
         }
 
         try {
+
             final File inputFile = new File(smithwatermanData);
+            long inputBytes = inputFile.length();
             final FileReader input = new FileReader(inputFile);
             final BufferedReader in = new BufferedReader(input);
 

--- a/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
+++ b/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
@@ -1,7 +1,7 @@
 package com.intel.gkl.smithwaterman;
 
 import com.intel.gkl.IntelGKLUtils;
-import com.intel.gkl.testing_utils.TestingUtils;
+import com.intel.gkl.testingutils.TestingUtils;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWParameters;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWOverhangStrategy;
 import org.broadinstitute.gatk.nativebindings.smithwaterman.SWNativeAlignerResult;

--- a/src/test/java/com/intel/gkl/testing_utils/TestingUtils.java
+++ b/src/test/java/com/intel/gkl/testing_utils/TestingUtils.java
@@ -1,0 +1,24 @@
+package com.intel.gkl.testing_utils;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+public class TestingUtils {
+    public static final int MAX_SW_SEQUENCE_LENGTH = 32*1024-1; //2^15 - 1
+    public static final int MAX_SW_MATCH_VALUE = 64*1024; // 2^16
+    static SecureRandom rng = new SecureRandom();
+
+    public static void randomDNA(byte[] array) {
+        final byte[] DNA_CHARS = {'A', 'C', 'G', 'T'};
+
+        for (int i = 0; i < array.length; i++) {
+            array[i] = DNA_CHARS[rng.nextInt(DNA_CHARS.length)];
+        }
+    }
+
+    public static byte[] generateRandomDNAArray(int size){
+        byte[] dna = new byte[size];
+        randomDNA(dna);
+        return dna;
+    }
+}

--- a/src/test/java/com/intel/gkl/testingutils/TestingUtils.java
+++ b/src/test/java/com/intel/gkl/testingutils/TestingUtils.java
@@ -1,7 +1,6 @@
-package com.intel.gkl.testing_utils;
+package com.intel.gkl.testingutils;
 
 import java.security.SecureRandom;
-import java.util.Arrays;
 
 public class TestingUtils {
     public static final int MAX_SW_SEQUENCE_LENGTH = 32*1024-1; //2^15 - 1


### PR DESCRIPTION
As a result of the current implementation limitations (integer data types), the maximum sequence length is 2^15 -1 ~ 32k bytes
Thus, the maximum matching value is ~ 2^16 + 2 `(max_sequence_length * match_value <= int32_max_value)`

**Parameter validation was added to the SmithWaterman Java class:**
- Neither reference nor aligned sequences can be longer than 2^15-1
- Matching value cannot be greater than 2^16 (rounded)

If any of those conditions is not satisfied `IllegalArgumentException` is raised

**The worst-case scenario is tested:**
- Alignment of two identical sequences of the maximum length
- Match value is set to 2^16
