### PR TITLE
Remove GZIP Deflater support for Level 2

### DIFF
--- a/src/main/java/com/intel/gkl/compression/IntelDeflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelDeflater.java
@@ -93,6 +93,10 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
         if ((level < 0 || level > 9) && level != DEFAULT_COMPRESSION) {
             throw new IllegalArgumentException("Illegal compression level");
         }
+	if ((level == 1 || level == 2) && nowrap == false) {
+	    throw new IllegalArgumentException("Compression configuration requested not supported");
+	}
+ 
         this.level = level;
         this.nowrap = nowrap;
         strategy = DEFAULT_STRATEGY;
@@ -105,7 +109,7 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
      * @param level the compression level (0-9)
      */
     public IntelDeflater(int level) {
-        this(level, false);
+        this(level, true);
     }
 
     /**
@@ -113,7 +117,7 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
      * Compressed data will be generated in ZLIB format.
      */
     public IntelDeflater() {
-        this(DEFAULT_COMPRESSION, false);
+        this(DEFAULT_COMPRESSION, true);
     }
 
     @Override

--- a/src/main/java/com/intel/gkl/compression/IntelDeflaterFactory.java
+++ b/src/main/java/com/intel/gkl/compression/IntelDeflaterFactory.java
@@ -31,14 +31,17 @@ public class IntelDeflaterFactory extends DeflaterFactory {
      */
     public Deflater makeDeflater(final int compressionLevel, final boolean gzipCompatible) {
         if (intelDeflaterSupported) {
-            if ((compressionLevel == 1 && gzipCompatible) || compressionLevel != 1) {
-                return new IntelDeflater(compressionLevel, gzipCompatible);
-            }
-        }
-        logger.warn("IntelDeflater is not supported, using Java.util.zip.Deflater");
-        return new Deflater(compressionLevel, gzipCompatible);
-    }
+	      try {
+                    return new IntelDeflater(compressionLevel, gzipCompatible); 
+              } catch  (IllegalArgumentException e) {
+                    logger.warn("Invalid configuration requsted, using Java.util.zip.Deflater");
+	      }
+    	} else {
+                    logger.warn("Intel Deflater not supported, using Java.util.zip.Deflater");
+	       }
 
+        return new Deflater(compressionLevel, gzipCompatible);
+   }
     public boolean usingIntelDeflater() {
         return intelDeflaterSupported;
     }

--- a/src/main/java/com/intel/gkl/compression/IntelInflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflater.java
@@ -97,7 +97,7 @@ public final class IntelInflater extends Inflater implements NativeLibrary {
      * Compressed data will be generated in ZLIB format.
      */
     public IntelInflater() {
-        this(false);
+        this(true);
     }
 
     @Override


### PR DESCRIPTION
* Compresison level 1 and 2 return the Java Deflator when Gzip is requested.
Level 1 was allready done extend to level 2.

* Do input validation in IntelDeflater and propagate exceptions.

* Change the class default for both Inflation and Deflation to False.

signed-off-by: Keith Mannthey@intel.com