### PR TITLE
AEJ 1625 - check added for input output buffer length and test cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,16 +79,23 @@ test.dependsOn copyNativeLib
 //===================================================================
 
 test {
-    useTestNG()
+    def longTestsEnabled = System.getProperty('long_tests')
 
+    def additionalJvmArgs = []
+
+    if (longTestsEnabled != null){
+        additionalJvmArgs.add '-Xmx24G'
+    }
+    useTestNG {
+    }
     // propagate system properties to test JVM
     systemProperties = System.getProperties()
 
     if (project.hasProperty('debug')) {
-        jvmArgs '-verbose:jni', '-Xcheck:jni', '-XX:+RestoreMXCSROnJNICalls'
+        jvmArgs('-verbose:jni', '-Xcheck:jni', '-XX:+RestoreMXCSROnJNICalls', *additionalJvmArgs)
     }
     else {
-        jvmArgs '-Xcheck:jni', '-XX:+RestoreMXCSROnJNICalls'
+        jvmArgs('-Xcheck:jni', '-XX:+RestoreMXCSROnJNICalls', *additionalJvmArgs)
     }
 
     testLogging {

--- a/src/main/java/com/intel/gkl/compression/IntelDeflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelDeflater.java
@@ -199,6 +199,10 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
         if(len <= 0) {
             throw new ArrayIndexOutOfBoundsException("Length value is less or equal than zero");
         }
+        if(inputBuffer == null || inputBufferLength == 0) {
+            throw new NullPointerException("Input buffer is null");
+        }
+
 
         return deflateNative(b, len);
     }

--- a/src/main/java/com/intel/gkl/compression/IntelDeflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelDeflater.java
@@ -90,12 +90,14 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
      * @param nowrap if true then use GZIP compatible compression
      */
     public IntelDeflater(int level, boolean nowrap) {
+
         if ((level < 0 || level > 9) && level != DEFAULT_COMPRESSION) {
             throw new IllegalArgumentException("Illegal compression level");
         }
-	if ((level == 1 || level == 2) && nowrap == false) {
-	    throw new IllegalArgumentException("Compression configuration requested not supported");
-	}
+
+        if ((level == 1 || level == 2) && nowrap == false) {
+            throw new IllegalArgumentException("Compression configuration requested not supported");
+        }
  
         this.level = level;
         this.nowrap = nowrap;
@@ -203,8 +205,10 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
             throw new NullPointerException("Input buffer is null");
         }
 
-
-        return deflateNative(b, len);
+        int bytesWritten = deflateNative(b, len);
+        if(bytesWritten == 0)
+            logger.warn(String.format(" Zero Bytes Written : %d", bytesWritten));
+        return bytesWritten;
     }
 
     /**

--- a/src/main/java/com/intel/gkl/compression/IntelInflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflater.java
@@ -169,6 +169,9 @@ public final class IntelInflater extends Inflater implements NativeLibrary {
         if(off > b.length - len) {
             throw new ArrayIndexOutOfBoundsException("Length value exceeds permissible range");
         }
+        if(inputBuffer == null || inputBufferLength == 0) {
+            throw new NullPointerException("Input buffer is null");
+        }
 
         return inflateNative(b, off, len);
     }

--- a/src/main/java/com/intel/gkl/compression/IntelInflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflater.java
@@ -176,7 +176,10 @@ public final class IntelInflater extends Inflater implements NativeLibrary {
             throw new NullPointerException("Input buffer is null");
         }
 
-        return inflateNative(b, off, len);
+        int bytesWritten = inflateNative(b, off, len);
+        if(bytesWritten == 0)
+            logger.warn(String.format("Zero Bytes Written : %d", bytesWritten));
+        return bytesWritten;
     }
 
     /**

--- a/src/main/java/com/intel/gkl/compression/IntelInflaterFactory.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflaterFactory.java
@@ -12,7 +12,7 @@ import java.util.zip.Inflater;
  * Created by pnvaidya on 2/1/17.
  */
 public class IntelInflaterFactory extends InflaterFactory {
-    private final static Logger logger = LogManager.getLogger(IntelDeflaterFactory.class);
+    private final static Logger logger = LogManager.getLogger(IntelInflaterFactory.class);
     private boolean intelInflaterSupported;
 
     public IntelInflaterFactory(File tmpDir) {

--- a/src/main/native/compression/IntelDeflater.cc
+++ b/src/main/native/compression/IntelDeflater.cc
@@ -142,7 +142,7 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelDeflater_resetNative
               int ret = deflateInit2(lz_stream, level,  Z_DEFLATED,
                                      nowrap ? -MAX_WBITS : MAX_WBITS,
                                      DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
-              if (ret != Z_OK) {
+              if (ret != Z_OK ) {
                 if(env->ExceptionCheck())
                     env->ExceptionClear();
                 env->ThrowNew(env->FindClass("java/lang/RuntimeException"),"IntelDeflater init error");
@@ -236,7 +236,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
   jint level = env->GetIntField(obj, FID_level);
   const char* err_msg;
 
-  if( outputBufferLength <= 0 || inputBufferLength <= 0 )
+  if( outputBufferLength == 0 || inputBufferLength == 0 )
   {
           if (env->ExceptionCheck())
               env->ExceptionClear();
@@ -244,7 +244,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
           return -1;
   }
 
-  if(level == 1 || level ==2 ) {
+  if(level == 1 || level == 2 ) {
   
         isal_zstream* lz_stream = (isal_zstream*)env->GetLongField(obj, FID_lz_stream);
 
@@ -271,7 +271,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
         lz_stream->next_out = (uint8_t*) (next_out);
         lz_stream->avail_out = outputBufferLength ;
 
-        int bytes_in = inputBufferLength;
+        DBG("Compressing");
 
         #ifdef profile
             struct timeval  tv1, tv2;
@@ -328,9 +328,8 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
         long bytes_out = outputBufferLength - lz_stream->avail_out;
         if(bytes_out == 0 )
         {
-            err_msg = "No bytes wriNtten";
             env->ExceptionClear();
-            env->ThrowNew(env->FindClass("java/lang/RuntimeException"), err_msg);
+            env->ThrowNew(env->FindClass("java/lang/RuntimeException"), "No bytes written");
             return -1;
         }
         
@@ -369,7 +368,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
         lz_stream->next_out = (Bytef *) next_out;
         lz_stream->avail_out = (uInt) outputBufferLength;
 
-        int bytes_in = inputBufferLength;
+        DBG("Decompressing");
 
         #ifdef profile
             struct timeval  tv1, tv2;
@@ -411,23 +410,15 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
           env->ThrowNew(env->FindClass("java/lang/RuntimeException"), err_msg);
           return -1;
         }
-        if( lz_stream->next_out - lz_stream->total_out <= 0)
-        {
-            const char* err_msg;
-            env->ExceptionClear();
-            err_msg = "Buffer overflow issue";
-            env->ThrowNew(env->FindClass("java/lang/RuntimeException"), err_msg);
-            return -1;
-        }
 
          int bytes_out = outputBufferLength - lz_stream->avail_out;
-         if(bytes_out == 0 || lz_stream->avail_out == 0)
+         if(bytes_out == 0)
          {
-                    err_msg = "No bytes written";
-                    env->ExceptionClear();
-                    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), err_msg);
-                    return -1;
+            env->ExceptionClear();
+            env->ThrowNew(env->FindClass("java/lang/RuntimeException"), "No bytes written");
+            return -1;
          }
+         DBG ("bytes_out = %d \n", bytes_out);
          return bytes_out;
 
     }

--- a/src/main/native/compression/IntelDeflater.cc
+++ b/src/main/native/compression/IntelDeflater.cc
@@ -83,76 +83,74 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelDeflater_resetNative
  
   jint level = env->GetIntField(obj, FID_level);
 
-
   if(level == 1 || level ==2) {
-    isal_zstream* lz_stream = (isal_zstream*)env->GetLongField(obj, FID_lz_stream);
 
-    if (lz_stream == 0) {
-      lz_stream = (isal_zstream*)malloc(sizeof(isal_zstream));
-      if ( lz_stream == NULL ) {
-        if(env->ExceptionCheck())
-            env->ExceptionClear();
-        env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
-        return;
-      }
+        isal_zstream* lz_stream = (isal_zstream*)env->GetLongField(obj, FID_lz_stream);
+        if (lz_stream == 0) {
+              lz_stream = (isal_zstream*)malloc(sizeof(isal_zstream));
+              if ( lz_stream == NULL ) {
+                if(env->ExceptionCheck())
+                    env->ExceptionClear();
+                env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
+                return;
+              }
 
+               isal_deflate_stateless_init(lz_stream);
 
-       isal_deflate_stateless_init(lz_stream);
+               lz_stream->level = level;
+               lz_stream->level_buf = (uint8_t*)malloc(ISAL_DEF_LVL2_DEFAULT);
+               lz_stream->level_buf_size = ISAL_DEF_LVL2_DEFAULT;
 
-    lz_stream->level = level;
-    lz_stream->level_buf = (uint8_t*)malloc(ISAL_DEF_LVL2_DEFAULT);
-    lz_stream->level_buf_size = ISAL_DEF_LVL2_DEFAULT;
+              if (lz_stream->level_buf == NULL) {
+                  if(env->ExceptionCheck()) {
+                    env->ExceptionClear();
+                  }
+                  env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
+                  free(lz_stream);
+                  return;
+              }
 
-      if (lz_stream->level_buf == NULL) {
-          if(env->ExceptionCheck()) {
-            env->ExceptionClear();
-          }
-          env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
-          free(lz_stream);
-          return;
-      }
+              env->SetLongField(obj, FID_lz_stream, (jlong)lz_stream);
+        }
+        else {
 
-      env->SetLongField(obj, FID_lz_stream, (jlong)lz_stream);
-    }
-    else {
+          isal_deflate_stateless_init(lz_stream);
 
-      isal_deflate_stateless_init(lz_stream);
+        }
 
-    }
+        lz_stream->end_of_stream = 0;
 
-    lz_stream->end_of_stream = 0;
-  
-   // DBG("lz_stream = 0x%lx", (long)lz_stream);
+       // DBG("lz_stream = 0x%lx", (long)lz_stream);
   }
   else {
-    
-    z_stream* lz_stream = (z_stream*)env->GetLongField(obj, FID_lz_stream);
 
-    if (lz_stream == 0) {
-      lz_stream = (z_stream*)calloc(1, sizeof(z_stream));
-      if ( lz_stream == NULL ) {
-        if(env->ExceptionCheck())
-            env->ExceptionClear();
-        env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
-        return;
-      }
-      env->SetLongField(obj, FID_lz_stream, (jlong)lz_stream);
-      
-      lz_stream->zalloc = Z_NULL;
-      lz_stream->zfree = Z_NULL;
-      lz_stream->opaque = Z_NULL;
-      int ret = deflateInit2(lz_stream, level,  Z_DEFLATED,
-                             nowrap ? -MAX_WBITS : MAX_WBITS,
-                             DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
-      if (ret != Z_OK) {
-        if(env->ExceptionCheck())
-            env->ExceptionClear();
-        env->ThrowNew(env->FindClass("java/lang/RuntimeException"),"IntelDeflater init error");
-      }
-    }
-    else {
-      deflateReset(lz_stream);
-    }
+        z_stream* lz_stream = (z_stream*)env->GetLongField(obj, FID_lz_stream);
+
+        if (lz_stream == 0) {
+              lz_stream = (z_stream*)calloc(1, sizeof(z_stream));
+              if ( lz_stream == NULL ) {
+                if(env->ExceptionCheck())
+                    env->ExceptionClear();
+                env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
+                return;
+              }
+              env->SetLongField(obj, FID_lz_stream, (jlong)lz_stream);
+
+              lz_stream->zalloc = Z_NULL;
+              lz_stream->zfree = Z_NULL;
+              lz_stream->opaque = Z_NULL;
+              int ret = deflateInit2(lz_stream, level,  Z_DEFLATED,
+                                     nowrap ? -MAX_WBITS : MAX_WBITS,
+                                     DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+              if (ret != Z_OK) {
+                if(env->ExceptionCheck())
+                    env->ExceptionClear();
+                env->ThrowNew(env->FindClass("java/lang/RuntimeException"),"IntelDeflater init error");
+              }
+        }
+        else {
+          deflateReset(lz_stream);
+        }
 
 
   }
@@ -170,59 +168,61 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_compression_IntelDeflater_generateHuff
       jint level = env->GetIntField(obj, FID_level);
 
       if(level == 1) {
-      isal_zstream* lz_stream = (isal_zstream*)env->GetLongField(obj, FID_lz_stream);
-      if (lz_stream == NULL) {
-        if(env->ExceptionCheck())
+          isal_zstream* lz_stream = (isal_zstream*)env->GetLongField(obj, FID_lz_stream);
+          if (lz_stream == NULL) {
+            if(env->ExceptionCheck())
+                env->ExceptionClear();
+            env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "lz_stream is NULL.");
+            return;
+          }
+
+          jbyteArray inputBuffer = (jbyteArray)env->GetObjectField(obj, FID_inputBuffer);
+          jbyte* input = (jbyte*)env->GetPrimitiveArrayCritical(inputBuffer, 0);
+
+          if (input == NULL) {
+            if (env->ExceptionCheck())
+              env->ExceptionClear();
+            env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "inputBuffer is null.");
+            env->ReleasePrimitiveArrayCritical(inputBuffer, input, 0);
+            return;
+          }
+
+          struct isal_huff_histogram *histogram = (struct isal_huff_histogram *) malloc(sizeof(*histogram));
+          struct isal_hufftables *hufftables_custom;
+
+          if (histogram == NULL) {
+            DBG ("Malloc failed out of memory");
+            if(env->ExceptionCheck())
+                env->ExceptionClear();
+            env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
+            env->ReleasePrimitiveArrayCritical(inputBuffer, input, 0);
+            return;
+          }
+
+          memset(histogram, 0, sizeof(isal_huff_histogram));
+          isal_update_histogram((unsigned char*)input, 64*1024, histogram);
+
+          if (isal_create_hufftables(hufftables_custom, histogram) != 0) {
             env->ExceptionClear();
-        env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "lz_stream is NULL.");
-        return;
-      }
+            env->ThrowNew(env->FindClass("java/lang/RuntimeException"), "Invalid huffman code was created.");
+            env->ReleasePrimitiveArrayCritical(inputBuffer, input, 0);
+            free(histogram);
+            return;
+          }
 
-      jbyteArray inputBuffer = (jbyteArray)env->GetObjectField(obj, FID_inputBuffer);
-      jbyte* input = (jbyte*)env->GetPrimitiveArrayCritical(inputBuffer, 0);
+          lz_stream->hufftables = hufftables_custom;
 
-      if (input == NULL) {
-        if (env->ExceptionCheck())
-          env->ExceptionClear();
-        env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "inputBuffer is null.");
-        env->ReleasePrimitiveArrayCritical(inputBuffer, input, 0);
-        return;
-      }
+          env->ReleasePrimitiveArrayCritical(inputBuffer, input, 0);
 
-      struct isal_huff_histogram *histogram = (struct isal_huff_histogram *) malloc(sizeof(*histogram)); 
-      struct isal_hufftables *hufftables_custom;
-
-      if (histogram == NULL) {
-        DBG ("Malloc failed out of memory");
-        if(env->ExceptionCheck())
-            env->ExceptionClear();
-        env->ThrowNew(env->FindClass("java/lang/OutOfMemoryError"),"Memory allocation error");
-        env->ReleasePrimitiveArrayCritical(inputBuffer, input, 0);
-        return;
-      }
-
-      memset(histogram, 0, sizeof(isal_huff_histogram));
-      isal_update_histogram((unsigned char*)input, 64*1024, histogram);
-
-      if (isal_create_hufftables(hufftables_custom, histogram) != 0) {
-        env->ExceptionClear();
-        env->ThrowNew(env->FindClass("java/lang/RuntimeException"), "Invalid huffman code was created.");
-        env->ReleasePrimitiveArrayCritical(inputBuffer, input, 0);
-        free(histogram);
-        return;
-      }
-
-      lz_stream->hufftables = hufftables_custom;
-
-      env->ReleasePrimitiveArrayCritical(inputBuffer, input, 0);
-      
-      free(histogram);
+          free(histogram);
       }
 
 }
 
 /**
  *  Deflate the data.
+ *  isa-l check isalExternal/igzip/igzip_rand_test.c
+ *  zib check src/main/native/compression/otc_zlib/zutil.c
  */
 JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNative
 (JNIEnv * env, jobject obj, jbyteArray outputBuffer, jint outputBufferLength) {
@@ -234,181 +234,198 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
   //jint inputBufferOffset = env->GetIntField(obj, FID_inputBufferOffset);
   jboolean endOfStream = env->GetBooleanField(obj, FID_endOfStream);
   jint level = env->GetIntField(obj, FID_level);
+  const char* err_msg;
 
 
   if(level == 1 || level ==2 ) {
   
-    isal_zstream* lz_stream = (isal_zstream*)env->GetLongField(obj, FID_lz_stream);
+        isal_zstream* lz_stream = (isal_zstream*)env->GetLongField(obj, FID_lz_stream);
 
-    isal_zstream stream;
+        jbyte* next_in = (jbyte*)env->GetPrimitiveArrayCritical(inputBuffer, 0);
+        if (next_in == NULL ) {
+          if (env->ExceptionCheck())
+            env->ExceptionClear();
+          env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "inputBuffer is null.");
+          return -1;
+        }
 
-    jbyte* next_in = (jbyte*)env->GetPrimitiveArrayCritical(inputBuffer, 0);
+        jbyte* next_out = (jbyte*)env->GetPrimitiveArrayCritical(outputBuffer, 0);
+        if (next_out == NULL ) {
+          if (env->ExceptionCheck())
+            env->ExceptionClear();
+          env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "outputBuffer is null.");
+          env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
+          return -1;
+        }
 
-    if (next_in == NULL) {
-      if (env->ExceptionCheck())
-        env->ExceptionClear();
-      env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "inputBuffer is null.");
-      return -1;
-    }
+        lz_stream->next_in = (uint8_t*) (next_in);
+        lz_stream->avail_in = inputBufferLength;
+        lz_stream->end_of_stream = endOfStream;
+        lz_stream->next_out = (uint8_t*) (next_out);
+        lz_stream->avail_out = outputBufferLength ;
 
-    jbyte* next_out = (jbyte*)env->GetPrimitiveArrayCritical(outputBuffer, 0);
-    if (next_out == NULL) {
-      if (env->ExceptionCheck())
-        env->ExceptionClear();
-      env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "outputBuffer is null.");
-      env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
-      return -1;
-    }
+        int bytes_in = inputBufferLength;
+        // TODO add check here
 
-    lz_stream->next_in = (uint8_t*) (next_in);
-    lz_stream->avail_in = inputBufferLength;
-    lz_stream->end_of_stream = endOfStream;
-    lz_stream->next_out = (uint8_t*) (next_out);
-    lz_stream->avail_out = outputBufferLength ;
+        #ifdef profile
+            struct timeval  tv1, tv2;
+            gettimeofday(&tv1, NULL);
+        #endif
 
-    int bytes_in = inputBufferLength;
+        // compress and update lz_stream state
+        int ret = isal_deflate_stateless(lz_stream);
 
-#ifdef profile
-    struct timeval  tv1, tv2;
-    gettimeofday(&tv1, NULL);
-#endif
+        #ifdef profile
+            gettimeofday(&tv2, NULL);
+            DBG ("Total time = %f seconds\n",
+                     (double) (tv2.tv_usec - tv1.tv_usec) / 1000000 +
+                     (double) (tv2.tv_sec - tv1.tv_sec));
+        #endif
 
-    // compress and update lz_stream state
-    int ret = isal_deflate_stateless(lz_stream);
+        DBG ("avail_out = %d \n",lz_stream->avail_out );
 
-#ifdef profile
-    gettimeofday(&tv2, NULL);
-    DBG ("Total time = %f seconds\n",
-             (double) (tv2.tv_usec - tv1.tv_usec) / 1000000 +
-             (double) (tv2.tv_sec - tv1.tv_sec));
-#endif
+        // release buffers
+        env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
+        env->ReleasePrimitiveArrayCritical(outputBuffer, next_out, 0);
 
+        // set finished if endOfStream was set and all input processed
+        if (endOfStream && lz_stream->avail_in == 0) {
+          env->SetBooleanField(obj, FID_finished, true);
+        }
 
-      DBG ("avail_out = %d \n",lz_stream->avail_out );
+        if (ret != COMP_OK) {
+              
+              switch (ret) {
+                case INVALID_FLUSH:
+                  err_msg = "Invalid FLUSH selected.";
+                  break;
+                case ISAL_INVALID_LEVEL:
+                  err_msg = "Invalid compression level set.";
+                  break;
+                case ISAL_INVALID_LEVEL_BUF:
+                  err_msg = "Level buffer is not large enough.";
+                  break;
+                case STATELESS_OVERFLOW:
+                  err_msg = "Output buffer too small.";
+                  break;
+                default:
+                  err_msg = "isal_deflate_stateless returned an unknown return code.";
+                  DBG("isal_deflate_stateless returned %d", ret);
+              }
 
+              env->ExceptionClear();
+              env->ThrowNew(env->FindClass("java/lang/RuntimeException"), err_msg);
+              return -1;
+        }
 
-
-    // release buffers
-    env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
-    env->ReleasePrimitiveArrayCritical(outputBuffer, next_out, 0);
-
-    // set finished if endOfStream was set and all input processed
-    if (endOfStream && lz_stream->avail_in == 0) {
-      env->SetBooleanField(obj, FID_finished, true);
-    }
-
-    if (ret != COMP_OK) {
-      const char* msg;
-      switch (ret) {
-        case INVALID_FLUSH:
-          msg = "Invalid FLUSH selected.";
-          break;
-        case ISAL_INVALID_LEVEL:
-          msg = "Invalid compression level set.";
-          break;
-        case ISAL_INVALID_LEVEL_BUF:
-          msg = "Level buffer is not large enough.";
-          break;
-        case STATELESS_OVERFLOW:
-          msg = "Output buffer too small.";
-          break;
-        default:
-          msg = "isal_deflate_stateless returned an unknown return code.";
-          DBG("isal_deflate_stateless returned %d", ret);
-      }
-
-      env->ExceptionClear();
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), msg);
-      return -1;
-    }
-
-    // return number of bytes written to output buffer
-    long bytes_out = outputBufferLength - lz_stream->avail_out;
-    DBG ("bytes_out = %d \n", bytes_out);
-    return bytes_out;
+        // return number of bytes written to output buffer
+        long bytes_out = outputBufferLength - lz_stream->avail_out;
+        if(bytes_out == 0 )
+        {
+            err_msg = "No bytes wriNtten";
+            env->ExceptionClear();
+            env->ThrowNew(env->FindClass("java/lang/RuntimeException"), err_msg);
+            return -1;
+        }
+        
+        DBG ("bytes_out = %d \n", bytes_out);
+        return bytes_out;
   }
   else {
       
-    z_stream* lz_stream = (z_stream*)env->GetLongField(obj, FID_lz_stream);
+        z_stream* lz_stream = (z_stream*)env->GetLongField(obj, FID_lz_stream);
+        if (lz_stream == NULL) {
+          if(env->ExceptionCheck())
+              env->ExceptionClear();
+          env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "lz_stream is NULL.");
+          return -1;
+        }
 
-    if (lz_stream == NULL) {
-      if(env->ExceptionCheck())
+        jbyte* next_in = (jbyte*)env->GetPrimitiveArrayCritical(inputBuffer, 0);
+        if (next_in == NULL ) {
+          if (env->ExceptionCheck())
+            env->ExceptionClear();
+          env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "inputBuffer is null.");
+          return -1;
+        }
+
+        jbyte* next_out = (jbyte*)env->GetPrimitiveArrayCritical(outputBuffer, 0);
+        if (next_out == NULL ) {
+          if (env->ExceptionCheck())
+            env->ExceptionClear();
+          env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "outputBuffer is null.");
+          env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
+          return -1;
+        }
+
+        lz_stream->next_in = (Bytef *) next_in;
+        lz_stream->avail_in = (uInt) inputBufferLength;
+        lz_stream->next_out = (Bytef *) next_out;
+        lz_stream->avail_out = (uInt) outputBufferLength;
+
+        int bytes_in = inputBufferLength;
+        // TODO add check here
+
+        #ifdef profile
+            struct timeval  tv1, tv2;
+            gettimeofday(&tv1, NULL);
+        #endif
+
+        // compress and update lz_stream state
+        int ret = deflate(lz_stream, Z_FINISH);
+
+        #ifdef profile
+             gettimeofday(&tv2, NULL);
+             DBG ("Total time = %f seconds\n",
+                      (double) (tv2.tv_usec - tv1.tv_usec) / 1000000 +
+                      (double) (tv2.tv_sec - tv1.tv_sec));
+        #endif
+
+        // release buffers
+        env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
+        env->ReleasePrimitiveArrayCritical(outputBuffer, next_out, 0);
+
+        if (ret == Z_STREAM_END && lz_stream->avail_in == 0) {
+          env->SetBooleanField(obj, FID_finished, true);
+        }
+        else if (ret != Z_OK) {
+          const char* err_msg;
+          switch (ret) {
+            case Z_STREAM_ERROR:
+              err_msg = "Stream state is inconsistent.";
+              break;
+            case Z_BUF_ERROR:
+              err_msg = "No progress possible. Buffer error.";
+              break;
+            default:
+              err_msg = zError(ret);
+              DBG("deflate returned %d", err_msg);
+          }
+
           env->ExceptionClear();
-      env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "lz_stream is NULL.");
-      return -1;
+          env->ThrowNew(env->FindClass("java/lang/RuntimeException"), err_msg);
+          return -1;
+        }
+        if( lz_stream->next_out - lz_stream->total_out <= 0)
+        {
+            const char* err_msg;
+            env->ExceptionClear();
+            err_msg = "Buffer overflow issue";
+            env->ThrowNew(env->FindClass("java/lang/RuntimeException"), err_msg);
+            return -1;
+        }
+
+         int bytes_out = outputBufferLength - lz_stream->avail_out;
+         if(bytes_out == 0 || lz_stream->avail_out == 0)
+         {
+                    err_msg = "No bytes written";
+                    env->ExceptionClear();
+                    env->ThrowNew(env->FindClass("java/lang/RuntimeException"), err_msg);
+                    return -1;
+         }
+         return bytes_out;
+
     }
-
-    jbyte* next_in = (jbyte*)env->GetPrimitiveArrayCritical(inputBuffer, 0);
-
-    if (next_in == NULL) {
-      if (env->ExceptionCheck())
-        env->ExceptionClear();
-      env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "inputBuffer is null.");
-      return -1;
-    }
-
-    jbyte* next_out = (jbyte*)env->GetPrimitiveArrayCritical(outputBuffer, 0);
-
-    if (next_out == NULL) {
-      if (env->ExceptionCheck())
-        env->ExceptionClear();
-      env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "outputBuffer is null.");
-      env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
-      return -1;
-    }
-
-    lz_stream->next_in = (Bytef *) next_in;
-    lz_stream->avail_in = (uInt) inputBufferLength;
-    lz_stream->next_out = (Bytef *) next_out;
-    lz_stream->avail_out = (uInt) outputBufferLength;
-      
-    int bytes_in = inputBufferLength;
-
-
-#ifdef profile
-    struct timeval  tv1, tv2;
-    gettimeofday(&tv1, NULL);
-#endif
-    // compress and update lz_stream state
-    int ret = deflate(lz_stream, Z_FINISH);
-
- #ifdef profile
-     gettimeofday(&tv2, NULL);
-
-     DBG ("Total time = %f seconds\n",
-              (double) (tv2.tv_usec - tv1.tv_usec) / 1000000 +
-              (double) (tv2.tv_sec - tv1.tv_sec));
- #endif
-
-    // release buffers
-    env->ReleasePrimitiveArrayCritical(inputBuffer, next_in, 0);
-    env->ReleasePrimitiveArrayCritical(outputBuffer, next_out, 0);
-
-    if (ret == Z_STREAM_END && lz_stream->avail_in == 0) { 
-      env->SetBooleanField(obj, FID_finished, true);
-    } else if (ret != Z_OK) {
-      const char* msg;
-
-      switch (ret) {
-        case Z_STREAM_ERROR:
-          msg = "Stream state is inconsistent.";
-          break;
-        case Z_BUF_ERROR:
-          msg = "No progress possible.";
-          break;
-        default:
-          msg = "deflate returned an unknown return code.";
-          DBG("deflate returned %d", ret);
-      }
-
-      env->ExceptionClear();
-      env->ThrowNew(env->FindClass("java/lang/RuntimeException"), msg);
-      return -1;
-    }
-
-    int bytes_out = outputBufferLength - lz_stream->avail_out;
-    return bytes_out;
-  }
 }
 
 /**
@@ -418,19 +435,19 @@ JNIEXPORT void JNICALL
 Java_com_intel_gkl_compression_IntelDeflater_endNative(JNIEnv *env, jobject obj)
 {
   jint level = env->GetIntField(obj, FID_level);
+
    if (level == 1 || level == 2 ) {
-     isal_zstream* lz_stream = (isal_zstream*)env->GetLongField(obj, FID_lz_stream);
+      isal_zstream* lz_stream = (isal_zstream*)env->GetLongField(obj, FID_lz_stream);
+      isal_deflate_reset(lz_stream);
       free(lz_stream->level_buf);
       free(lz_stream);
-      env->SetLongField(obj, FID_lz_stream, 0);
-
    }
-  else {
-    z_stream* lz_stream = (z_stream*)env->GetLongField(obj, FID_lz_stream);
-    deflateEnd(lz_stream);
-    free(lz_stream);
-    env->SetLongField(obj, FID_lz_stream, 0);
+   else {
+      z_stream* lz_stream = (z_stream*)env->GetLongField(obj, FID_lz_stream);
+      deflateReset(lz_stream);
+      free(lz_stream);
   }
 
+  env->SetLongField(obj, FID_lz_stream, 0);
 
 }

--- a/src/main/native/compression/IntelDeflater.cc
+++ b/src/main/native/compression/IntelDeflater.cc
@@ -236,6 +236,13 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
   jint level = env->GetIntField(obj, FID_level);
   const char* err_msg;
 
+  if( outputBufferLength <= 0 || inputBufferLength <= 0 )
+  {
+          if (env->ExceptionCheck())
+              env->ExceptionClear();
+          env->ThrowNew(env->FindClass("java/lang/NullPointerException"), " Buffer size not right.");
+          return -1;
+  }
 
   if(level == 1 || level ==2 ) {
   
@@ -265,7 +272,6 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
         lz_stream->avail_out = outputBufferLength ;
 
         int bytes_in = inputBufferLength;
-        // TODO add check here
 
         #ifdef profile
             struct timeval  tv1, tv2;
@@ -364,7 +370,6 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelDeflater_deflateNativ
         lz_stream->avail_out = (uInt) outputBufferLength;
 
         int bytes_in = inputBufferLength;
-        // TODO add check here
 
         #ifdef profile
             struct timeval  tv1, tv2;

--- a/src/main/native/compression/IntelInflater.cc
+++ b/src/main/native/compression/IntelInflater.cc
@@ -102,22 +102,31 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
 
 
 
-   inflate_state* lz_stream = (inflate_state*)env->GetLongField(obj, FID_inf_lz_stream);
-   if (lz_stream == NULL) {
-     if (env->ExceptionCheck())
-       env->ExceptionClear();
-     env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "lz_stream is NULL.");
-     return 0;
-   }
-
    jbyteArray inputBuffer = (jbyteArray)env->GetObjectField(obj, FID_inf_inputBuffer);
    jint inputBufferLength = env->GetIntField(obj, FID_inf_inputBufferLength);
    jint inputBufferOffset = env->GetIntField(obj, FID_inf_inputBufferOffset);
 
+   if( outputBufferLength <= 0 || outputBufferOffset >= outputBufferLength
+        || inputBufferLength <= 0  || inputBufferOffset >= inputBufferLength
+        || outputBufferLength < inputBufferLength/2 )
+   {
+        if (env->ExceptionCheck())
+            env->ExceptionClear();
+        env->ThrowNew(env->FindClass("java/lang/NullPointerException"), " Buffer size not right.");
+        return -1;
+
+   }
+
+   inflate_state* lz_stream = (inflate_state*)env->GetLongField(obj, FID_inf_lz_stream);
+      if (lz_stream == NULL) {
+        if (env->ExceptionCheck())
+          env->ExceptionClear();
+        env->ThrowNew(env->FindClass("java/lang/NullPointerException"), "lz_stream is NULL.");
+        return 0;
+      }
 
    jbyte* next_in = (jbyte*)env->GetPrimitiveArrayCritical(inputBuffer, 0);
-   if (next_in == NULL || inputBufferLength == 0
-         || inputBufferOffset > inputBufferLength || inputBufferOffset < 0)
+   if (next_in == NULL )
    {
           if (env->ExceptionCheck())
             env->ExceptionClear();
@@ -126,8 +135,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
    }
 
    jbyte* next_out = (jbyte*)env->GetPrimitiveArrayCritical(outputBuffer, 0);
-   if (next_out == NULL || outputBufferLength == 0
-                || outputBufferOffset > outputBufferLength)
+   if (next_out == NULL )
    {
           if (env->ExceptionCheck())
             env->ExceptionClear();
@@ -153,7 +161,6 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
         gettimeofday(&tv1, NULL);
     #endif
 
-    //int ret = isal_inflate(lz_stream);
     int ret = isal_inflate(lz_stream);
 
     #ifdef profile

--- a/src/main/native/compression/IntelInflater.cc
+++ b/src/main/native/compression/IntelInflater.cc
@@ -106,13 +106,12 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
    jint inputBufferLength = env->GetIntField(obj, FID_inf_inputBufferLength);
    jint inputBufferOffset = env->GetIntField(obj, FID_inf_inputBufferOffset);
 
-   if( outputBufferLength <= 0 || outputBufferOffset >= outputBufferLength
-        || inputBufferLength <= 0  || inputBufferOffset >= inputBufferLength
-        || outputBufferLength < inputBufferLength/2 )
+
+   if(  inputBufferLength == 0 )
    {
         if (env->ExceptionCheck())
             env->ExceptionClear();
-        env->ThrowNew(env->FindClass("java/lang/NullPointerException"), " Buffer size not right.");
+        env->ThrowNew(env->FindClass("java/lang/NullPointerException"), " Uncompress Buffer size not right.");
         return -1;
 
    }
@@ -149,8 +148,6 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
    lz_stream->avail_in = (uInt) inputBufferLength;
    lz_stream->next_out = (Bytef *) (next_out + outputBufferOffset);
    lz_stream->avail_out = (uInt) outputBufferLength;
-
-   int bytes_in = inputBufferLength;
 
    DBG("Decompressing");
 
@@ -221,12 +218,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_compression_IntelInflater_inflateNativ
         }
 
         int bytes_out = outputBufferLength - lz_stream->avail_out;
-        if(bytes_out <= 0 )
-        {
-            env->ExceptionClear();
-            env->ThrowNew(env->FindClass("java/lang/RuntimeException"), "No bytes written");
-            return -1;
-        }
+
         return bytes_out;
 }
 

--- a/src/main/native/pairhmm/IntelPairHmm.cc
+++ b/src/main/native/pairhmm/IntelPairHmm.cc
@@ -124,25 +124,37 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_pairhmm_IntelPairHmm_computeLikelihood
   //==================================================================
   // calcutate pairHMM
 
-#ifdef _OPENMP
-  #pragma omp parallel for schedule(dynamic, 1) num_threads(g_max_threads)
-#endif
-  for (int i = 0; i < testcases.size(); i++) {
-    double result_final = 0;
+   try {
 
-    float result_float = g_use_double ? 0.0f : g_compute_full_prob_float(&testcases[i]);
+     #ifdef _OPENMP
+          #pragma omp parallel for schedule(dynamic, 1) num_threads(g_max_threads)
+     #endif
 
-    if (result_float < MIN_ACCEPTED) {
-      double result_double = g_compute_full_prob_double(&testcases[i]);
-      result_final = log10(result_double) - g_ctxd.LOG10_INITIAL_CONSTANT;
+    for (int i = 0; i < testcases.size(); i++) {
+
+        double result_final = 0;
+
+        float result_float = g_use_double ? 0.0f : g_compute_full_prob_float(&testcases[i]);
+
+        if (result_float < MIN_ACCEPTED) {
+          double result_double = g_compute_full_prob_double(&testcases[i]);
+          result_final = log10(result_double) - g_ctxd.LOG10_INITIAL_CONSTANT;
+        }
+        else {
+          result_final = (double)(log10f(result_float) - g_ctxf.LOG10_INITIAL_CONSTANT);
+        }
+
+        javaResults[i] = result_final;
+        DBG("result = %e", result_final);
+      }
+
     }
-    else {
-      result_final = (double)(log10f(result_float) - g_ctxf.LOG10_INITIAL_CONSTANT);
+    catch (JavaException& e) {
+       env->ExceptionClear();
+       env->ThrowNew(env->FindClass(e.classPath), e.message);
+       return;
     }
 
-    javaResults[i] = result_final;
-    DBG("result = %e", result_final);
-  }
 
   DBG("Exit");
 }
@@ -156,5 +168,5 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_pairhmm_IntelPairHmm_computeLikelihood
 JNIEXPORT void JNICALL Java_com_intel_gkl_pairhmm_IntelPairHmm_doneNative
 (JNIEnv* env, jobject obj)
 {
-
+    //javaData(env);
 }

--- a/src/main/native/pairhmm/IntelPairHmm.cc
+++ b/src/main/native/pairhmm/IntelPairHmm.cc
@@ -124,37 +124,35 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_pairhmm_IntelPairHmm_computeLikelihood
   //==================================================================
   // calcutate pairHMM
 
-   try {
+    try {
+        #ifdef _OPENMP
+              #pragma omp parallel for schedule(dynamic, 1) num_threads(g_max_threads)
+        #endif
+        for (int i = 0; i < testcases.size(); i++) {
 
-     #ifdef _OPENMP
-          #pragma omp parallel for schedule(dynamic, 1) num_threads(g_max_threads)
-     #endif
+            double result_final = 0;
+            float result_float = g_use_double ? 0.0f : g_compute_full_prob_float(&testcases[i]);
 
-    for (int i = 0; i < testcases.size(); i++) {
+            if (result_float < MIN_ACCEPTED) {
+              double result_double = g_compute_full_prob_double(&testcases[i]);
+              result_final = log10(result_double) - g_ctxd.LOG10_INITIAL_CONSTANT;
+            }
+            else {
+              result_final = (double)(log10f(result_float) - g_ctxf.LOG10_INITIAL_CONSTANT);
+            }
 
-        double result_final = 0;
-
-        float result_float = g_use_double ? 0.0f : g_compute_full_prob_float(&testcases[i]);
-
-        if (result_float < MIN_ACCEPTED) {
-          double result_double = g_compute_full_prob_double(&testcases[i]);
-          result_final = log10(result_double) - g_ctxd.LOG10_INITIAL_CONSTANT;
-        }
-        else {
-          result_final = (double)(log10f(result_float) - g_ctxf.LOG10_INITIAL_CONSTANT);
-        }
-
-        javaResults[i] = result_final;
-        DBG("result = %e", result_final);
-      }
-
+            javaResults[i] = result_final;
+            DBG("result = %e", result_final);
+          }
     }
     catch (JavaException& e) {
+       #ifdef _OPENMP
+            #pragma omp barrier
+       #endif
        env->ExceptionClear();
-       env->ThrowNew(env->FindClass(e.classPath), e.message);
+       env->ThrowNew(env->FindClass(e.classPath), "Error in pairhmm processing.");
        return;
     }
-
 
   DBG("Exit");
 }
@@ -168,5 +166,4 @@ JNIEXPORT void JNICALL Java_com_intel_gkl_pairhmm_IntelPairHmm_computeLikelihood
 JNIEXPORT void JNICALL Java_com_intel_gkl_pairhmm_IntelPairHmm_doneNative
 (JNIEnv* env, jobject obj)
 {
-    //javaData(env);
 }

--- a/src/test/java/com/intel/gkl/compression/DeflaterUnitTest.java
+++ b/src/test/java/com/intel/gkl/compression/DeflaterUnitTest.java
@@ -172,7 +172,7 @@ public class DeflaterUnitTest extends CompressionUnitTestBase {
     }
 
     @Test(enabled = true, expectedExceptions = NullPointerException.class)
-    public void deflateEmprtylInputBufferTest() {
+    public void deflateEmptyInputBufferTest() {
         final Deflater deflater = new IntelDeflaterFactory().makeDeflater(0, true);
         int LEN = 10;
         byte[] inputBuffer = new byte[0];

--- a/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
+++ b/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
@@ -85,6 +85,59 @@ public class InflaterUnitTest {
 
         Assert.fail();
     }
+    @Test(enabled = true, expectedExceptions = NullPointerException.class)
+    public void inflateNullInputBufferFailsTest() throws DataFormatException {
+        final Inflater inflater = new IntelInflaterFactory().makeInflater(true);
+        byte[] output = new byte[10];
+        try
+        {
+            inflater.inflate(output, 0, 10);
+        }
+        catch(Exception e){
+            log.error(e.getMessage());
+            throw e;
+        }
+        Assert.fail();
+    }
+    @Test(enabled = true)
+    public void inflateNullBufferOverflowTest() throws DataFormatException, java.io.UnsupportedEncodingException
+    {
+        boolean nowrap = false;
+        int level = 2;
+        final Inflater inflater = new IntelInflaterFactory().makeInflater(nowrap);
+        final IntelDeflaterFactory intelDeflaterFactory = new IntelDeflaterFactory();
+        final Deflater deflater = intelDeflaterFactory.makeDeflater(level, nowrap);
+
+        try
+        {
+            String sequence = "ACTGTC";
+            byte[] input = sequence.getBytes("UTF-8");
+            byte[] output = new byte[1024];
+            byte[] result = new byte[1024];
+
+            deflater.setInput(input);
+            deflater.finish();
+            int compressedDataLength = deflater.deflate(output,0,1024);
+            deflater.end();
+            log.info(String.format("Compressed length : %d Seq : %s" , compressedDataLength ,
+                    new String(output, "UTF8")));
+
+            inflater.setInput(output, 0, compressedDataLength);
+            int resultLength = inflater.inflate(result, 0 , 1024);
+            inflater.end();
+
+            // Decode the bytes into a String
+            String seq2 = new String(result, 0, resultLength);
+            log.info(String.format("UnCompressed length : %d Seq : %s" , seq2.length() ,
+                    seq2));
+            Assert.assertEquals(sequence, seq2);
+        }
+        catch(Exception dfe){
+            log.error(dfe.getMessage());
+            //dfe.printStackTrace();
+        }
+
+    }
 
     @Test(enabled = true, expectedExceptions = ArrayIndexOutOfBoundsException.class)
     public void inflateThrowsNArrayIndexOutOfBoundsExceptionLengthLessThanZeroTest() throws DataFormatException {

--- a/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
+++ b/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
@@ -106,7 +106,7 @@ public class InflaterUnitTest extends CompressionUnitTestBase {
     public void inflateOutputBufferOverflowShortTest() throws DataFormatException, java.io.UnsupportedEncodingException
     {
         boolean nowrap = true;
-        int level = 2;
+        int level = 1;
         final Inflater inflater = new IntelInflaterFactory().makeInflater(nowrap);
         final IntelDeflaterFactory intelDeflaterFactory = new IntelDeflaterFactory();
         final Deflater deflater = intelDeflaterFactory.makeDeflater(level, nowrap);
@@ -115,8 +115,8 @@ public class InflaterUnitTest extends CompressionUnitTestBase {
         {
             String sequence = "ACTGTC";
             byte[] input = sequence.getBytes("UTF-8");
-            byte[] compressed = new byte[2*sequence.length()];
-            byte[] result = new byte[sequence.length()/2];
+            byte[] compressed = new byte[sequence.length()];
+            byte[] result = new byte[sequence.length() - 2];
 
             deflater.setInput(input);
             deflater.finish();
@@ -130,15 +130,13 @@ public class InflaterUnitTest extends CompressionUnitTestBase {
             inflater.end();
 
             String seq2 = new String(result, 0, resultLength);
-            log.info(String.format("UnCompressed length : %d Seq : %s" , seq2.length() ,
-                    seq2));
+            log.info(String.format("UnCompressed length : %d Seq : %s" , seq2.length() ,  seq2));
             Assert.assertEquals(sequence, seq2);
         }
-        catch(Exception dfe){
+        catch(RuntimeException dfe){
             log.error(dfe.getMessage());
             throw dfe;
         }
-        Assert.fail();
     }
     @Test(enabled = true, expectedExceptions = NullPointerException.class)
     public void inflateEmptyInputBufferSetOverflowTest() throws DataFormatException, java.io.UnsupportedEncodingException
@@ -154,7 +152,7 @@ public class InflaterUnitTest extends CompressionUnitTestBase {
             int resultLength = inflater.inflate(result, 0 , 1024);
             inflater.end();
         }
-        catch(Exception dfe) {
+        catch(RuntimeException dfe) {
             log.error(dfe.getMessage());
             throw dfe;
         }


### PR DESCRIPTION
### Deflater & Inflater code & java test cases changes
> - corrected intendation for native code
> - setInput not used and input Buffer len 
> - added warning for bytes out as 0
> - verified with usecase exception native propagting for incorrect buffer size 
> - isal doesn't have nowrap added explicit test to check that 

### PairHMM
> - Added generic try catch over omp for and barrier in catch