### PR TITLE
AEJ - 1625 SmithWaterman size one align array

### DIFF
--- a/src/main/java/com/intel/gkl/smithwaterman/IntelSmithWaterman.java
+++ b/src/main/java/com/intel/gkl/smithwaterman/IntelSmithWaterman.java
@@ -106,7 +106,7 @@ public class IntelSmithWaterman implements SWAlignerNativeBinding {
             throw new NullPointerException("OverhangStrategy is null.");
 
         int intStrategy =  getStrategy(overhangStrategy);
-        byte[] cigar = new byte[2*Integer.max(refArray.length, altArray.length)];
+        byte[] cigar = new byte[2*Integer.max(refArray.length, altArray.length) + 1];
 
         if(refArray.length > MAX_SW_SEQUENCE_LENGTH || altArray.length > MAX_SW_SEQUENCE_LENGTH){
             throw new IllegalArgumentException(String.format("Sequences exceed maximum length of %d bytes", MAX_SW_SEQUENCE_LENGTH));
@@ -119,7 +119,9 @@ public class IntelSmithWaterman implements SWAlignerNativeBinding {
             throw new IllegalArgumentException("Strategy is invalid.");
 
         try {
+
             offset = alignNative(refArray, altArray, cigar, parameters.getMatchValue(), parameters.getMismatchPenalty(), parameters.getGapOpenPenalty(), parameters.getGapExtendPenalty(), intStrategy);
+
         }  catch (OutOfMemoryError e) {
             logger.warn("Exception thrown from native SW alignNative function call %s", e.getMessage());
             throw new OutOfMemoryError("Memory allocation failed");

--- a/src/main/native/smithwaterman/PairWiseSW.h
+++ b/src/main/native/smithwaterman/PairWiseSW.h
@@ -386,7 +386,7 @@ void inline getCIGAR(SeqPair *p, int16_t *cigarBuf_, int32_t tid)
 
     }
 
-    int maxSize = max(p->len1, p->len2);
+    int maxSize = 2*max(p->len1, p->len2) + 1;
     int curSize = 0;
     for(i = newId; i >= 0; i--)
     {

--- a/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
+++ b/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
@@ -88,7 +88,7 @@ public class SmithWatermanUnitTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void smithWatermanThrowsIllegalArgumentExceptionIfAlignSequenceLengthTooLong(){
         final IntelSmithWaterman sw = new IntelSmithWaterman();
-        int sequenceLength = TestingUtils.MAX_SW_SEQUENCE_LENGTH+1;
+        int sequenceLength = TestingUtils.MAX_SW_SEQUENCE_LENGTH + 1;
 
         byte[] ref = new byte[]{'T', 'C', 'C', 'G'};
         byte[] align = TestingUtils.generateRandomDNAArray(sequenceLength);
@@ -97,6 +97,26 @@ public class SmithWatermanUnitTest {
         sw.align(ref, align, SWparameters, SWOverhangStrategy.IGNORE);
 
         Assert.fail();
+    }
+
+    @Test(enabled = true)
+    public void smithWatermanAlignArraySizeOne(){
+
+        final IntelSmithWaterman sw = new IntelSmithWaterman();
+        final boolean isLoaded = sw.load(null);
+
+        byte[] ref = new byte[]{'G','T','A'};
+        byte[] align = new byte[]{'A'};
+        SWParameters SWparameters = new SWParameters(100, -1 ,-3, -5);
+
+        try {
+            SWNativeAlignerResult result = sw.align(ref, align, SWparameters, SWOverhangStrategy.IGNORE);
+            logger.info(String.format("Using IntelSmithWaterman Library : %b, Offset : %d, Cigar : %s",isLoaded, result.alignment_offset, result.cigar));
+        }
+        catch(Exception | Error e){
+            logger.error(e.getMessage());
+        }
+
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
- Added unit test and changes for array size 1
- extra buffer for null terminator for cigar.length >= 2*len + 1