### PR TITLE
AEJ-2490 - Prevent Buffer Overflow in Smith Waterman

### DIFF
--- a/src/main/native/smithwaterman/IntelSmithWaterman.cc
+++ b/src/main/native/smithwaterman/IntelSmithWaterman.cc
@@ -20,7 +20,7 @@
 static jfieldID FID_reflength;
 static jfieldID FID_altlength;
 
-int32_t (*g_runSWOnePairBT)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int16_t *cigarCount, int32_t *offset);
+int32_t (*g_runSWOnePairBT)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int32_t cigarLen, int16_t *cigarCount, int32_t *offset);
 
 JNIEXPORT void JNICALL Java_com_intel_gkl_smithwaterman_IntelSmithWaterman_initNative
   (JNIEnv * env, jclass obj )
@@ -51,6 +51,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_smithwaterman_IntelSmithWaterman_align
 {
     jint refLength = env->GetArrayLength(ref);
     jint altLength = env->GetArrayLength(alt);
+    jint cigarLength = env->GetArrayLength(cigar);
 
     jbyte* reference = (jbyte*)env->GetPrimitiveArrayCritical(ref, 0);
     jbyte* alternate = (jbyte*)env->GetPrimitiveArrayCritical(alt, 0);
@@ -80,8 +81,7 @@ JNIEXPORT jint JNICALL Java_com_intel_gkl_smithwaterman_IntelSmithWaterman_align
     int32_t offset = 0;
 
     // call the low level routine
-    int32_t result = g_runSWOnePairBT(match, mismatch, open, extend,(uint8_t*) reference, (uint8_t*) alternate,refLength, altLength, strategy, (char *) cigarArray, (int16_t*) &count, &offset);
-
+    int32_t result = g_runSWOnePairBT(match, mismatch, open, extend, (uint8_t*) reference, (uint8_t*) alternate, refLength, altLength, strategy, (char *) cigarArray, cigarLength, (int16_t*) &count, &offset);
     // release buffers
     env->ReleasePrimitiveArrayCritical(ref, reference, 0);
     env->ReleasePrimitiveArrayCritical(alt, alternate, 0);

--- a/src/main/native/smithwaterman/PairWiseSW.h
+++ b/src/main/native/smithwaterman/PairWiseSW.h
@@ -386,7 +386,6 @@ void inline getCIGAR(SeqPair *p, int16_t *cigarBuf_, int32_t cigarBufLength, int
 
     }
 
-    int maxSize = max(p->len1, p->len2);
     int curSize = 0;
     for(i = newId; i >= 0; i--)
     {

--- a/src/main/native/smithwaterman/PairWiseSW.h
+++ b/src/main/native/smithwaterman/PairWiseSW.h
@@ -238,7 +238,7 @@ void inline smithWatermanBackTrack(SeqPair *p, int32_t match, int32_t mismatch, 
     return;
 }
 
-void inline getCIGAR(SeqPair *p, int16_t *cigarBuf_, int32_t tid)
+void inline getCIGAR(SeqPair *p, int16_t *cigarBuf_, int32_t cigarBufLength, int32_t tid)
 {
     int16_t *btrack = p->btrack;
     int32_t max_i = p->max_i;
@@ -333,7 +333,7 @@ void inline getCIGAR(SeqPair *p, int16_t *cigarBuf_, int32_t tid)
     if(overhangStrategy == SOFTCLIP)
     {
         if(j > 0)
-        {
+        {   
             cigarArray[cigarId * 2] = SOFTCLIP;
             cigarArray[cigarId * 2 + 1] = j;
             cigarId++;
@@ -351,7 +351,7 @@ void inline getCIGAR(SeqPair *p, int16_t *cigarBuf_, int32_t tid)
         p->alignmentOffset = i - j;
     }
     else // overhangStrategy == INDEL || overhangStrategy == LEADING_INDEL
-    {
+    {   
         if (i > 0)
         {
             cigarArray[cigarId * 2] = DELETE;
@@ -410,20 +410,35 @@ void inline getCIGAR(SeqPair *p, int16_t *cigarBuf_, int32_t tid)
                 state = 'R';
                 break;
         }
-	// expectedLength for converting int to str w/ extra padding for '\0'
-	int expectedLength = snprintf( NULL, 0, "%d%c", cigarArray[2 * i + 1], state);
-	if (curSize >= 0 && expectedLength > 1 && (curSize < maxSize - expectedLength ))
-           {
-                   curSize += snprintf(p->cigar + curSize, expectedLength + 1, "%d%c", cigarArray[2 * i + 1], state);
-           }
+        // expectedLength for converting int to str w/ extra padding for '\0'
+	    int expectedLength = snprintf( NULL, 0, "%d%c", cigarArray[2 * i + 1], state);
+        if (curSize >= 0 && expectedLength > 1){ 
+            
+            int tempNewCurSize = curSize + expectedLength;
+
+            if (tempNewCurSize < cigarBufLength)
+            {
+                curSize += snprintf(p->cigar + curSize, expectedLength + 1, "%d%c", cigarArray[2 * i + 1], state);
+            }
+
+            else if (tempNewCurSize == cigarBufLength)
+            {
+                char * tempBuff = (char*) malloc(sizeof(char) * (expectedLength + 1));
+                snprintf(tempBuff, expectedLength + 1, "%d%c", cigarArray[2 * i + 1], state);
+                
+                strncpy(p->cigar + curSize, tempBuff, expectedLength);
+                curSize += expectedLength;
+                
+                free(tempBuff);
+            }   
+        }
     }
     p->cigarCount = strnlen(p->cigar, curSize);
 }
 
 
-int32_t CONCAT(runSWOnePairBT_,SIMD_ENGINE)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int16_t *cigarCount, int32_t *offset)
+int32_t CONCAT(runSWOnePairBT_,SIMD_ENGINE)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int32_t cigarLen, int16_t *cigarCount, int32_t *offset)
 {
-
     int32_t  w_match = match;
     int32_t  w_mismatch = mismatch;
     int32_t  w_open = open;
@@ -459,7 +474,7 @@ int32_t CONCAT(runSWOnePairBT_,SIMD_ENGINE)(int32_t match, int32_t mismatch, int
     p.cigar = cigarArray;
 
     smithWatermanBackTrack(&p, match, mismatch,  open, extend, E_, 0);
-    getCIGAR(&p, cigarBuf_, 0);
+    getCIGAR(&p, cigarBuf_, cigarLen, 0);
     (*cigarCount) = p.cigarCount;
 
     _mm_free(E_);

--- a/src/main/native/smithwaterman/avx2_impl.cc
+++ b/src/main/native/smithwaterman/avx2_impl.cc
@@ -2,6 +2,4 @@
 
 #include "avx2-smithwaterman.h"
 
-int32_t (*runSWOnePairBT_fp_avx2)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int16_t *cigarCount, int32_t *offset)= &runSWOnePairBT_avx2;
-
-
+int32_t (*runSWOnePairBT_fp_avx2)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int32_t cigarLen, int16_t *cigarCount, int32_t *offset)= &runSWOnePairBT_avx2;

--- a/src/main/native/smithwaterman/avx2_impl.h
+++ b/src/main/native/smithwaterman/avx2_impl.h
@@ -3,7 +3,7 @@
 
 #include "smithwaterman_common.h"
 
-extern int32_t (*runSWOnePairBT_fp_avx2)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int16_t *cigarCount, int32_t *offset);
+extern int32_t (*runSWOnePairBT_fp_avx2)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int32_t cigarLen, int16_t *cigarCount, int32_t *offset);
 
 #endif //AVX2_IMPL_H
 

--- a/src/main/native/smithwaterman/avx512_impl.cc
+++ b/src/main/native/smithwaterman/avx512_impl.cc
@@ -4,12 +4,12 @@
 
 #include "avx512-smithwaterman.h"
 
-int32_t (*runSWOnePairBT_fp_avx512)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int16_t *cigarCount, int32_t *offset)= &runSWOnePairBT_avx512;
+int32_t (*runSWOnePairBT_fp_avx512)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int32_t cigarLen, int16_t *cigarCount, int32_t *offset)= &runSWOnePairBT_avx512;
 
 
 #else
 
-int32_t (*runSWOnePairBT_fp_avx512)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int16_t *cigarCount, int32_t *offset)= NULL;
+int32_t (*runSWOnePairBT_fp_avx512)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int32_t cigarLen, int16_t *cigarCount, int32_t *offset)= NULL;
 
 
 #endif

--- a/src/main/native/smithwaterman/avx512_impl.h
+++ b/src/main/native/smithwaterman/avx512_impl.h
@@ -3,8 +3,7 @@
 
 #include "smithwaterman_common.h"
 
-extern int32_t (*runSWOnePairBT_fp_avx512)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int16_t *cigarCount, int32_t *offset);
+extern int32_t (*runSWOnePairBT_fp_avx512)(int32_t match, int32_t mismatch, int32_t open, int32_t extend,uint8_t *seq1, uint8_t *seq2, int32_t len1, int32_t len2, int8_t overhangStrategy, char *cigarArray, int32_t cigarLen, int16_t *cigarCount, int32_t *offset);
 
 
 #endif //AVX512_IMPL_H
-

--- a/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
+++ b/src/test/java/com/intel/gkl/smithwaterman/SmithWatermanUnitTest.java
@@ -113,6 +113,33 @@ public class SmithWatermanUnitTest {
     }
 
     @Test(enabled = true)
+    public void singleElementSequencesAlignmentTest(){
+        final IntelSmithWaterman sw = new IntelSmithWaterman();
+        sw.load(null);
+
+        byte[] ref =    new byte [] {'C'};
+        byte[] align =  new byte [] {'C'};
+
+        SWParameters SWparameters = new SWParameters( 3,-2,-2,-1);
+        SWNativeAlignerResult result = sw.align(ref, align, SWparameters, SWOverhangStrategy.IGNORE);
+
+        Assert.assertEquals(result.cigar, "1M");
+    }
+    @Test(enabled = true)
+    public void twoElementSequencesAlignmentTest(){
+        final IntelSmithWaterman sw = new IntelSmithWaterman();
+        sw.load(null);
+
+        byte[] ref =    new byte [] {'A', 'D'};
+        byte[] align =  new byte [] {'A', 'T'};
+
+        SWParameters SWparameters = new SWParameters( 3,-5,-2,-1);
+        SWNativeAlignerResult result = sw.align(ref, align, SWparameters, SWOverhangStrategy.IGNORE);
+
+        Assert.assertEquals(result.cigar, "1M1I");
+    }
+
+    @Test(enabled = false)
     public void maxSequenceFullAlignmentTest(){
         final IntelSmithWaterman smithWaterman = new IntelSmithWaterman();
         final boolean isLoaded = smithWaterman.load(null);


### PR DESCRIPTION
Fixes:
- Wrongly assumed max cigar buffer size is equal to max(len1, len2)
- Trailing NULL string termination might've been causing buffer overflow in the Smith-Waterman cigar array
