### PR TITLE
Java 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,16 @@ jobs:
   include:
     - os: linux
       dist: trusty
-      jdk:
-        - oraclejdk8
-        - oraclejdk11
+      jdk: oraclejdk8
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk11
     - os: osx
       osx_image: xcode9.3
-      jdk:
-        - oraclejdk8
-        - oraclejdk11
+      jdk: oraclejdk8
+    - os: osx
+      osx_image: xcode9.3
+      jdk: oraclejdk11
 
 before_install:
     |

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ jobs:
   include:
     - os: linux
       dist: trusty
+      jdk:
+        - oraclejdk8
+        - oraclejdk11
     - os: osx
       osx_image: xcode9.3
-
-jdk:
-- oraclejdk8
-- oraclejdk11
+      jdk:
+        - oraclejdk8
+        - oraclejdk11
 
 before_install:
     |

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jobs:
 
 jdk:
 - oraclejdk8
+- oraclejdk11
 
 before_install:
     |

--- a/src/test/java/com/intel/gkl/compression/DeflaterUnitTest.java
+++ b/src/test/java/com/intel/gkl/compression/DeflaterUnitTest.java
@@ -57,7 +57,7 @@ public class DeflaterUnitTest extends CompressionUnitTestBase {
     public void setInputShortThrowsNullPointerExceptionWhenNullBufferTest(){
         final Deflater deflater = new IntelDeflaterFactory().makeDeflater(0, true);
 
-        deflater.setInput(null);
+        deflater.setInput((byte []) null);
 
         Assert.fail();
     }

--- a/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
+++ b/src/test/java/com/intel/gkl/compression/InflaterUnitTest.java
@@ -31,7 +31,7 @@ public class InflaterUnitTest extends CompressionUnitTestBase {
     public void setInputOneArgThrowsNullPointerExceptionWhenNullBufferTest(){
         final Inflater inflater = new IntelInflaterFactory().makeInflater(true);
 
-        inflater.setInput(null);
+        inflater.setInput((byte[]) null);
 
         Assert.fail();
     }
@@ -76,7 +76,7 @@ public class InflaterUnitTest extends CompressionUnitTestBase {
     public void inflateOneArgThrowsNullPointerExceptionWhenNullBufferTest() throws DataFormatException {
         final Inflater inflater = new IntelInflaterFactory().makeInflater(true);
 
-        inflater.inflate(null);
+        inflater.inflate((byte []) null);
 
         Assert.fail();
     }


### PR DESCRIPTION
Java is largely backward-compatible so only minor changes were required to have GKL build on Java 11. I also updated the Travis configuration to have the CI test both the Java 8 and Java 11 versions.

Example build: https://travis-ci.org/github/Intel-HLS/GKL/builds/762306908