### PR TITLE
Removed warning message based on issue #176

### DIFF
--- a/src/main/java/com/intel/gkl/compression/IntelDeflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelDeflater.java
@@ -203,8 +203,6 @@ public final class IntelDeflater extends Deflater implements NativeLibrary {
         }
 
         int bytesWritten = deflateNative(b, len);
-        if(bytesWritten == 0)
-            logger.warn(String.format(" Zero Bytes Written : %d", bytesWritten));
         return bytesWritten;
     }
 

--- a/src/main/java/com/intel/gkl/compression/IntelInflater.java
+++ b/src/main/java/com/intel/gkl/compression/IntelInflater.java
@@ -174,8 +174,6 @@ public final class IntelInflater extends Inflater implements NativeLibrary {
         }
 
         int bytesWritten = inflateNative(b, off, len);
-        if(bytesWritten == 0)
-            logger.warn(String.format("Zero Bytes Written : %d", bytesWritten));
         return bytesWritten;
     }
 


### PR DESCRIPTION
Removed "Zero bytes written" warning message from inflater and deflater as BGZF files has a empty terminator block and this message is confusing users.