### PR TITLE
Testng v7.5.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'org.broadinstitute:gatk-native-bindings:1.0.0'
     compile 'commons-logging:commons-logging:1.2'
     compile 'com.github.samtools:htsjdk:2.21.1'
-    testCompile 'org.testng:testng:7.4.0'
+    testCompile 'org.testng:testng:7.7.1'
 }
 
  wrapper {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'org.broadinstitute:gatk-native-bindings:1.0.0'
     compile 'commons-logging:commons-logging:1.2'
     compile 'com.github.samtools:htsjdk:2.21.1'
-    testCompile 'org.testng:testng:7.7.1'
+    testCompile 'org.testng:testng:7.5.1'
 }
 
  wrapper {


### PR DESCRIPTION
Updated testng version from 7.4.0 to 7.5.1 to address CVE-2022-4065.