### PR TITLE
Change from using the java plugin to the java-library plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id 'java-library'
     id 'maven-publish'
     id 'signing'
     id 'com.palantir.git-version' version '0.5.2'
@@ -20,9 +20,9 @@ repositories {
 
 dependencies {
     implementation 'commons-io:commons-io:2.7'
-    implementation 'org.broadinstitute:gatk-native-bindings:1.0.0'
     implementation 'commons-logging:commons-logging:1.2'
-    implementation 'com.github.samtools:htsjdk:3.0.5'
+    api 'org.broadinstitute:gatk-native-bindings:1.0.0'
+    api 'com.github.samtools:htsjdk:3.0.5'
     testImplementation 'org.testng:testng:7.5.1'
 }
 


### PR DESCRIPTION
I noticed when upgrading gkl 8.8.0 -> 8.11.0 in picard that there were build errors when doing so.  There were changes in gradle which make it so that it doesn't treat implementation dependencies of other projects as compile time dependencies.  This was causing issues because we didn't explicitly depend on gatk-native-library but it's part of the exposed API of the gkl which we call. 

Specifying these as API dependencies should fix the problem by letting gradle know that they are needed at compile time. 

My machine isn't set up to run the native build so I haven't tested this properly but I *think* it should work.  

(This is easy to work around by just adding explicit dependencies, but it would be better if it wasn't necessary.)
